### PR TITLE
Improved float point numbers parsing using number_format to avoid errors in order values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.php_cs.cache
 vendor/*

--- a/RedePay/Address/Address.php
+++ b/RedePay/Address/Address.php
@@ -8,168 +8,263 @@ namespace RedePay\Address;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Address {
+class Address
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
     use \RedePay\Utils\RemoveMask;
 
     /**
-     * @param String
+     * The alias
+     *
+     * @var string
      */
     private $alias;
 
     /**
-     * @param String
+     * The street
+     *
+     * @var string
      */
     private $street;
 
     /**
-     * @param String
+     * The number
+     *
+     * @var string
      */
     private $number;
 
     /**
-     * @param String
+     * The complement
+     *
+     * @var string
      */
     private $complement;
 
     /**
-     * @param String
+     * The postal code
+     *
+     * @var string
      */
     private $postalCode;
 
     /**
-     * @param String
+     * The district/neighborhood
+     *
+     * @var string
      */
     private $district;
 
     /**
-     * @param String
+     * The city
+     *
+     * @var string
      */
     private $city;
 
     /**
-     * @param String
+     * The state/province
+     *
+     * @var string
      */
     private $state;
 
     /**
-     * @param Address
+     * Address constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Address object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Sets the alias
+     *
+     * @param string $alias
+     * @return Address
      */
-    public function getAlias() {
+    public function setAlias($alias)
+    {
+        $this->alias = $alias;
+
+        return $this;
+    }
+
+    /**
+     * Gets the alias
+     *
+     * @return string
+     */
+    public function getAlias()
+    {
         return $this->alias;
     }
 
     /**
-     * @return String
+     * Sets the street name
+     *
+     * @param string $street
+     * @return Address
      */
-    public function getStreet() {
+    public function setStreet($street)
+    {
+        $this->street = $street;
+
+        return $this;
+    }
+
+    /**
+     * Gets the street name
+     *
+     * @return string
+     */
+    public function getStreet()
+    {
         return $this->street;
     }
 
     /**
-     * @return String
+     * Sets the number
+     *
+     * @param string $number
+     * @return Address
      */
-    public function getNumber() {
+    public function setNumber($number)
+    {
+        $this->number = $number;
+
+        return $this;
+    }
+
+    /**
+     * Gets the number
+     *
+     * @return string
+     */
+    public function getNumber()
+    {
         return $this->number;
     }
 
     /**
-     * @return String
+     * Sets the complement
+     *
+     * @param string $complement
+     * @return Address
      */
-    public function getComplement() {
+    public function setComplement($complement)
+    {
+        $this->complement = $complement;
+
+        return $this;
+    }
+
+    /**
+     * Gets the complement
+     *
+     * @return string
+     */
+    public function getComplement()
+    {
         return $this->complement;
     }
 
     /**
-     * @return String
+     * Sets the postal code
+     *
+     * @param string $postalCode
+     * @return Address
      */
-    public function getPostalCode() {
+    public function setPostalCode($postalCode)
+    {
+        $this->postalCode = $this->removeMask($postalCode);
+
+        return $this;
+    }
+
+    /**
+     * Gets the postal code
+     *
+     * @return string
+     */
+    public function getPostalCode()
+    {
         return $this->postalCode;
     }
 
     /**
-     * @return String
+     * Sets the district
+     *
+     * @param string $district
+     * @return Address
      */
-    public function getDistrict() {
+    public function setDistrict($district)
+    {
+        $this->district = $district;
+
+        return $this;
+    }
+
+    /**
+     * Gets the district
+     *
+     * @return string
+     */
+    public function getDistrict()
+    {
         return $this->district;
     }
 
     /**
-     * @return String
+     * Sets the city
+     *
+     * @param string $city
+     * @return Address
      */
-    public function getCity() {
+    public function setCity($city)
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    /**
+     * Gets the city
+     *
+     * @return string
+     */
+    public function getCity()
+    {
         return $this->city;
     }
 
     /**
-     * @return String
+     * Sets the state
+     *
+     * @param string $state
+     * @return Address
      */
-    public function getState() {
-        return $this->state;
-    }
-
-    /**
-     * @param String
-     */
-    public function setAlias($alias) {
-        $this->alias = $alias;
-    }
-
-    /**
-     * @param String
-     */
-    public function setStreet($street) {
-        $this->street = $street;
-    }
-
-    /**
-     * @param String
-     */
-    public function setNumber($number) {
-        $this->number = $number;
-    }
-
-    /**
-     * @param String
-     */
-    public function setComplement($complement) {
-        $this->complement = $complement;
-    }
-
-    /**
-     * @param String
-     */
-    public function setPostalCode($postalCode) {
-        $this->postalCode = $this->removeMask($postalCode);
-    }
-
-    /**
-     * @param String
-     */
-    public function setDistrict($district) {
-        $this->district = $district;
-    }
-
-    /**
-     * @param String
-     */
-    public function setCity($city) {
-        $this->city = $city;
-    }
-
-    /**
-     * @param String
-     */
-    public function setState($state) {
+    public function setState($state)
+    {
         $this->state = $state;
+
+        return $this;
+    }
+
+    /**
+     * Gets the state
+     *
+     * @return string
+     */
+    public function getState()
+    {
+        return $this->state;
     }
 }

--- a/RedePay/Address/Address.php
+++ b/RedePay/Address/Address.php
@@ -2,6 +2,9 @@
 
 namespace RedePay\Address;
 
+use RedePay\Utils\Fillable;
+use RedePay\Utils\RemoveMask;
+
 /**
  * Class Address
  *
@@ -13,8 +16,8 @@ class Address
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
-    use \RedePay\Utils\RemoveMask;
+    use Fillable;
+    use RemoveMask;
 
     /**
      * The alias

--- a/RedePay/Address/Address.php
+++ b/RedePay/Address/Address.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Address;
 
+/**
+ * Class Address
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Address {
     use \RedePay\Utils\Fillable;
     use \RedePay\Utils\RemoveMask;

--- a/RedePay/Customer/Customer.php
+++ b/RedePay/Customer/Customer.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Customer;
 
+/**
+ * Class Customer
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Customer {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Customer/Customer.php
+++ b/RedePay/Customer/Customer.php
@@ -4,6 +4,7 @@ namespace RedePay\Customer;
 
 use RedePay\Document\Document;
 use RedePay\Phone\Phone;
+use RedePay\Utils\Fillable;
 
 /**
  * Class Customer
@@ -16,7 +17,7 @@ class Customer
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * The customer name

--- a/RedePay/Customer/Customer.php
+++ b/RedePay/Customer/Customer.php
@@ -2,97 +2,150 @@
 
 namespace RedePay\Customer;
 
+use RedePay\Document\Document;
+use RedePay\Phone\Phone;
+
 /**
  * Class Customer
  *
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Customer {
+class Customer
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * The customer name
+     *
+     * @var string
      */
     private $name;
 
     /**
-     * @param String
+     * The customer email address
+     *
+     * @var string
      */
     private $email;
 
     /**
-     * @param Document[]
+     * The customer documents
+     *
+     * @var Document[]
      */
     private $documents;
 
     /**
-     * @param Phone[]
+     * The customer phone numbers
+     *
+     * @var Phone[]
      */
     private $phones;
 
     /**
-     * @param Customer
+     * Customer constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Customer object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @param String
+     * Sets the name
+     *
+     * @param string $name
+     * @return Customer
      */
-    public function getName() {
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets the name
+     *
+     * @return string
+     */
+    public function getName()
+    {
         return $this->name;
     }
 
     /**
-     * @param String
+     * Sets the email address
+     *
+     * @param string $email
+     * @return Customer
      */
-    public function getEmail() {
+    public function setEmail($email)
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * Gets the email
+     *
+     * @return string
+     */
+    public function getEmail()
+    {
         return $this->email;
     }
 
     /**
+     * Sets the documents array
+     *
+     * @param array $documents
+     * @return Customer
+     */
+    public function setDocuments(array $documents)
+    {
+        $this->documents = $documents;
+
+        return $this;
+    }
+
+    /**
+     * Gets the documents
+     *
      * @return Document[]
      */
-    public function getDocuments() {
+    public function getDocuments()
+    {
         return $this->documents;
     }
 
     /**
+     * Sets the phones array
+     *
+     * @param array $phones
+     * @return Customer
+     */
+    public function setPhones(array $phones)
+    {
+        $this->phones = $phones;
+
+        return $this;
+    }
+
+    /**
+     * Gets the phones
      * @return Phone[]
      */
-    public function getPhones() {
+    public function getPhones()
+    {
         return $this->phones;
-    }
-
-    /**
-     * @return String
-     */
-    public function setName($name) {
-        $this->name = $name;
-    }
-
-    /**
-     * @return String
-     */
-    public function setEmail($email) {
-        $this->email = $email;
-    }
-
-    /**
-     * @param Document[]
-     */
-    public function setDocuments($documents) {
-        $this->documents = $documents;
-    }
-
-    /**
-     * @param Phone[]
-     */
-    public function setPhones($phones) {
-        $this->phones = $phones;
     }
 }

--- a/RedePay/Document/Document.php
+++ b/RedePay/Document/Document.php
@@ -8,59 +8,93 @@ namespace RedePay\Document;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Document {
+class Document
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
     use \RedePay\Utils\Validation\CpfValidator;
 
     /**
-     * @param String
+     * Enum constants
+     */
+    const KIND_CPF = 'cpf';
+
+    /**
+     * The document type
+     *
+     * @var string
      */
     private $kind;
 
     /**
-     * @param String
+     * The document number
+     *
+     * @var string
      */
     private $number;
 
     /**
-     * @param Document
+     * Document constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Document object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Sets the kind
+     *
+     * @param string $kind
+     * @return Document
      */
-    public function getKind() {
+    public function setKind($kind)
+    {
+        $this->kind = $kind;
+
+        return $this;
+    }
+
+    /**
+     * Gets the kind
+     *
+     * @return string
+     */
+    public function getKind()
+    {
         return $this->kind;
     }
 
     /**
-     * @return String
+     * Sets the number
+     *
+     * @param string $number
+     * @throws \InvalidArgumentException
+     * @return Document
      */
-    public function getNumber() {
-        return $this->number;
-    }
-
-    /**
-     * @param String
-     */
-    public function setKind($kind) {
-        $this->kind = $kind;
-    }
-
-    /**
-     * @param String
-     */
-    public function setNumber($number) {
-        if($this->cpfValidator($number)) {
+    public function setNumber($number)
+    {
+        if ($this->cpfValidator($number)) {
             $this->number = $this->removeMask($number);
-        }
-        else {
+        } else {
             throw new \InvalidArgumentException($number ." is not a valid cpf value");
         }
+
+        return $this;
+    }
+
+    /**
+     * Gets the number
+     *
+     * @return string
+     */
+    public function getNumber()
+    {
+        return $this->number;
     }
 }

--- a/RedePay/Document/Document.php
+++ b/RedePay/Document/Document.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Document;
 
+/**
+ * Class Document
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Document {
     use \RedePay\Utils\Fillable;
     use \RedePay\Utils\Validation\CpfValidator;

--- a/RedePay/Document/Document.php
+++ b/RedePay/Document/Document.php
@@ -2,6 +2,9 @@
 
 namespace RedePay\Document;
 
+use RedePay\Utils\Fillable;
+use RedePay\Utils\Validation\CpfValidator;
+
 /**
  * Class Document
  *
@@ -13,8 +16,8 @@ class Document
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
-    use \RedePay\Utils\Validation\CpfValidator;
+    use Fillable;
+    use CpfValidator;
 
     /**
      * Enum constants

--- a/RedePay/History/History.php
+++ b/RedePay/History/History.php
@@ -2,6 +2,8 @@
 
 namespace RedePay\History;
 
+use RedePay\Utils\Fillable;
+
 /**
  * Class History
  *
@@ -13,7 +15,7 @@ class History
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * The date

--- a/RedePay/History/History.php
+++ b/RedePay/History/History.php
@@ -8,63 +8,90 @@ namespace RedePay\History;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class History {
+class History
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * The date
+     *
+     * @var string
      */
     private $date;
 
     /**
-     * @param String
+     * The status
+     *
+     * @var string
      */
     private $status;
 
     /**
-     * @param String
+     * The ID
+     *
+     * @var string
      */
     private $id;
 
     /**
-     * @param String
+     * The value
+     *
+     * @var string
      */
     private $value;
 
     /**
-     * @param History
+     * History constructor.
+     *
+     * @param array|null $data The default data to be filled in the current History object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Gets the date
+     *
+     * @return string
      */
-    public function getDate() {
+    public function getDate()
+    {
         return $this->date;
     }
 
     /**
-     * @return String
+     * Gets the status
+     *
+     * @return string
      */
-    public function getStatus() {
+    public function getStatus()
+    {
         return $this->status;
     }
 
     /**
-     * @return String
+     * Gets the ID
+     *
+     * @return string
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
     /**
-     * @return String
+     * Gets the value
+     *
+     * @return string
      */
-    public function getValue() {
+    public function getValue()
+    {
         return $this->value;
     }
 }

--- a/RedePay/History/History.php
+++ b/RedePay/History/History.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\History;
 
+/**
+ * Class History
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class History {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Item/Item.php
+++ b/RedePay/Item/Item.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Item;
 
+/**
+ * Class Item
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Item {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Item/Item.php
+++ b/RedePay/Item/Item.php
@@ -2,6 +2,8 @@
 
 namespace RedePay\Item;
 
+use RedePay\Utils\Fillable;
+
 /**
  * Class Item
  *
@@ -13,7 +15,7 @@ class Item
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * The item ID

--- a/RedePay/Item/Item.php
+++ b/RedePay/Item/Item.php
@@ -8,149 +8,222 @@ namespace RedePay\Item;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Item {
+class Item
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * The item ID
+     *
+     * @var string
      */
     private $id;
 
     /**
-     * @param String
+     * The item description
+     *
+     * @var string
      */
     private $description;
 
     /**
-     * @param integer
+     * The item amount
+     *
+     * @var float|int
      */
     private $amount;
 
     /**
-     * @param integer
+     * The item quantity
+     *
+     * @var int
      */
     private $quantity;
 
     /**
-     * @param integer
+     * The item freight amount
+     *
+     * @var float|int
      */
     private $freight;
 
     /**
-     * @param integer
+     * The item discount amount
+     *
+     * @var float|int
      */
     private $discount;
 
     /**
-     * @param Item
+     * Item constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Item object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Sets the ID
+     *
+     * @param string $id
+     * @return Item
      */
-    public function getId() {
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Gets the ID
+     *
+     * @return string
+     */
+    public function getId()
+    {
         return $this->id;
     }
 
     /**
-     * @return String
+     * Sets the description
+     *
+     * @param string $description
+     * @return Item
      */
-    public function getDescription() {
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Gets the description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
         return $this->description;
     }
 
     /**
-     * @return integer
+     * Sets the item amount
+     *
+     * @param float|int $amount
+     * @throws \InvalidArgumentException
+     * @return Item
      */
-    public function getAmount() {
+    public function setAmount($amount)
+    {
+        if (is_numeric($amount)) {
+            $this->amount = $amount;
+        } else {
+            throw new \InvalidArgumentException($amount ." is not a valid number value");
+        }
+
+        return $this;
+    }
+
+    /**
+     * Gets the item amount
+     *
+     * @return float|int
+     */
+    public function getAmount()
+    {
         return $this->amount;
     }
 
     /**
-     * @return integer
+     * Sets the quantity
+     *
+     * @param int $quantity
+     * @throws \InvalidArgumentException
+     * @return Item
      */
-    public function getQuantity() {
+    public function setQuantity($quantity)
+    {
+        if (is_numeric($quantity)) {
+            $this->quantity = $quantity;
+        } else {
+            throw new \InvalidArgumentException($quantity ." is not a valid number value");
+        }
+
+        return $this;
+    }
+
+    /**
+     * Gets the quantity
+     *
+     * @return int
+     */
+    public function getQuantity()
+    {
         return $this->quantity;
     }
 
     /**
-     * @return integer
+     * Sets the freight amount
+     *
+     * @param float|int $freight
+     * @throws \InvalidArgumentException
+     * @return Item
      */
-    public function getFreight() {
+    public function setFreight($freight)
+    {
+        if (is_numeric($freight)) {
+            $this->freight = $freight;
+        } else {
+            throw new \InvalidArgumentException($freight ." is not a valid number value");
+        }
+
+        return $this;
+    }
+
+    /**
+     * Gets the freight amount
+     *
+     * @return float|int
+     */
+    public function getFreight()
+    {
         return $this->freight;
     }
 
     /**
-     * @return integer
+     * Sets the discount amount
+     *
+     * @param float|int $discount
+     * @throws \InvalidArgumentException
+     * @return Item
      */
-    public function getDiscount() {
-        return $this->discount;
-    }
-
-    /**
-     * @param String
-     */
-    public function setId($id) {
-        $this->id = $id;
-    }
-
-    /**
-     * @param String
-     */
-    public function setDescription($description) {
-        $this->description = $description;
-    }
-
-    /**
-     * @param integer
-     */
-    public function setAmount($amount) {
-        if(is_numeric($amount)) {
-           $this->amount = $amount; 
-        }
-        else {
-            throw new \InvalidArgumentException($amount ." is not a valid number value");
-        }
-    }
-
-    /**
-     * @param integer
-     */
-    public function setQuantity($quantity) {
-        if(is_numeric($quantity)) {
-           $this->quantity = $quantity; 
-        }
-        else {
-            throw new \InvalidArgumentException($quantity ." is not a valid number value");
-        }
-    }
-
-    /**
-     * @param integer
-     */
-    public function setFreight($freight) {
-        if(is_numeric($freight)) {
-           $this->freight = $freight; 
-        }
-        else {
-            throw new \InvalidArgumentException($freight ." is not a valid number value");
-        }
-    }
-
-    /**
-     * @param integer
-     */
-    public function setDiscount($discount) {
-        if(is_numeric($discount)) {
-           $this->discount = $discount; 
-        }
-        else {
+    public function setDiscount($discount)
+    {
+        if (is_numeric($discount)) {
+            $this->discount = $discount;
+        } else {
             throw new \InvalidArgumentException($discount ." is not a valid number value");
         }
+
+        return $this;
+    }
+
+    /**
+     * Gets the discount amount
+     *
+     * @return float|int
+     */
+    public function getDiscount()
+    {
+        return $this->discount;
     }
 }

--- a/RedePay/Order/Order.php
+++ b/RedePay/Order/Order.php
@@ -2,248 +2,382 @@
 
 namespace RedePay\Order;
 
+use RedePay\Customer\Customer;
+use RedePay\History\History;
+use RedePay\Item\Item;
+use RedePay\Settings\Settings;
+use RedePay\Shipping\Shipping;
+use RedePay\Url\Url;
+
 /**
  * Class Order
  *
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Order {
+class Order
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * The order ID
+     *
+     * @var string
      */
     private $id;
 
     /**
-     * @param String
+     * Alias to $id
+     *
+     * @var string
      */
     private $orderId;
 
     /**
-     * @param String
+     * The order reference
+     *
+     * @var string
      */
     private $reference;
 
     /**
-     * @param String
+     * The order status
+     *
+     * @var string
      */
     private $status;
 
     /**
-     * @param String
+     * The order total amount
+     *
+     * @var string
      */
     private $amount;
 
     /**
-     * @param String
+     * The order creation date
+     *
+     * @var string
      */
     private $creationDate;
 
     /**
-     * @param String
+     * Alias to $creationDate
+     *
+     * @var string
      */
     private $createdAt;
 
     /**
-     * @param String
+     * The order discount amount
+     *
+     * @var float|int
      */
     private $discount;
 
     /**
-     * @param Customer
+     * The Customer
+     *
+     * @var Customer
      */
     private $customer;
 
     /**
-     * @param Shipping
+     * The Shipping
+     *
+     * @var Shipping
      */
     private $shipping;
 
     /**
-     * @param Item[]
+     * The order Items
+     *
+     * @var Item[]
      */
     private $items;
 
     /**
-     * @param History[]
+     * The order status history
+     *
+     * @var History[]
      */
     private $statusHistory;
 
     /**
-     * @param History[]
+     * The order transaction history
+     *
+     * @var History[]
      */
     private $transactionHistory;
 
     /**
-     * @param History[]
+     * The order reversal history
+     *
+     * @var History[]
      */
     private $reversalHistory;
 
     /**
-     * @param Settings
+     * The order settings
+     *
+     * @var Settings
      */
     private $settings;
 
     /**
-     * @param Url[]
+     * The order URLs
+     *
+     * @var Url[]
      */
     private $urls;
 
     /**
-     * @param Order
+     * Order constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Order object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Gets the ID
+     *
+     * @return string
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
     /**
-     * @return String
+     * Sets the reference
+     *
+     * @param string $reference
+     * @return Order
      */
-    public function getReference() {
+    public function setReference($reference)
+    {
+        $this->reference = $reference;
+
+        return $this;
+    }
+
+    /**
+     * Gets the reference
+     *
+     * @return string
+     */
+    public function getReference()
+    {
         return $this->reference;
     }
 
     /**
-     * @return String
+     * Gets the status
+     *
+     * @return string
      */
-    public function getStatus() {
+    public function getStatus()
+    {
         return $this->status;
     }
 
     /**
-     * @return String
+     * Gets the amount
+     *
+     * @return string
      */
-    public function getAmount() {
+    public function getAmount()
+    {
         return $this->amount;
     }
 
     /**
-     * @return String
+     * Gets the creation date
+     *
+     * @return string
      */
-    public function getCreationDate() {
+    public function getCreationDate()
+    {
         return $this->creationDate;
     }
 
     /**
-     * @return String
+     * Sets the discount amount
+     *
+     * @param float|int $discount
+     * @return Order
      */
-    public function getDiscount() {
+    public function setDiscount($discount)
+    {
+        if (is_numeric($discount)) {
+            $this->discount = $discount;
+        } else {
+            throw new \InvalidArgumentException($discount . ' is not a valid number value');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Gets the discount amount
+     *
+     * @return float|int
+     */
+    public function getDiscount()
+    {
         return $this->discount;
     }
 
     /**
+     * Sets the Customer
+     *
+     * @param Customer $customer
+     * @return Order
+     */
+    public function setCustomer(Customer $customer)
+    {
+        $this->customer = $customer;
+
+        return $this;
+    }
+
+    /**
+     * Gets the Customer
+     *
      * @return Customer
      */
-    public function getCustomer() {
+    public function getCustomer()
+    {
         return $this->customer;
     }
 
     /**
+     * Sets the Shipping
+     *
+     * @param Shipping $shipping
+     * @return Order
+     */
+    public function setShipping(Shipping $shipping)
+    {
+        $this->shipping = $shipping;
+
+        return $this;
+    }
+
+    /**
+     * Gets the Shipping
+     *
      * @return Shipping
      */
-    public function getShipping() {
+    public function getShipping()
+    {
         return $this->shipping;
     }
 
     /**
-     * @return Items[]
+     * Sets the items array
+     *
+     * @param array $items
+     * @return Order
      */
-    public function getItems() {
+    public function setItems(array $items)
+    {
+        $this->items = $items;
+
+        return $this;
+    }
+
+    /**
+     * Gets the items array
+     *
+     * @return Item[]
+     */
+    public function getItems()
+    {
         return $this->items;
     }
 
     /**
+     * Gets the status history
+     *
      * @return History[]
      */
-    public function getStatusHistory() {
+    public function getStatusHistory()
+    {
         return $this->statusHistory;
     }
 
     /**
+     * Gets the transaction history
+     *
      * @return History[]
      */
-    public function getTransactionHistory() {
+    public function getTransactionHistory()
+    {
         return $this->transactionHistory;
     }
 
     /**
+     * Gets the reversal history
+     *
      * @return History[]
      */
-    public function getReversalHistory() {
+    public function getReversalHistory()
+    {
         return $this->reversalHistory;
     }
 
     /**
+     * Sets the Settings
+     *
+     * @param Settings $settings
+     * @return Order
+     */
+    public function setSettings(Settings $settings)
+    {
+        $this->settings = $settings;
+
+        return $this;
+    }
+
+    /**
+     * Gets the Settings
+     *
      * @return Settings
      */
-    public function getSettings() {
+    public function getSettings()
+    {
         return $this->settings;
     }
 
     /**
+     * Sets the urls array
+     *
+     * @param array $urls
+     * @return Order
+     */
+    public function setUrls(array $urls)
+    {
+        $this->urls = $urls;
+
+        return $this;
+    }
+
+    /**
+     * Gets the urls array
+     *
      * @return Url[]
      */
-    public function getUrls() {
+    public function getUrls()
+    {
         return $this->urls;
-    }
-
-    /**
-     * @param String
-     */
-    public function setReference($reference) {
-        $this->reference = $reference;
-    }
-
-    /**
-     * @param Customer
-     */
-    public function setCustomer($customer) {
-        $this->customer = $customer;
-    }
-
-    /**
-     * @param Item[]
-     */
-    public function setItems($items) {
-        $this->items = $items;
-    }
-
-    /**
-     * @param String
-     */
-    public function setDiscount($discount) {
-        $this->discount = $discount;
-    }
-
-    /**
-     * @param Shipping
-     */
-    public function setShipping($shipping) {
-        $this->shipping = $shipping;
-    }
-
-    /**
-     * @param Settings
-     */
-    public function setSettings($settings) {
-        $this->settings = $settings;
-    }
-
-    /**
-     * @param Url[]
-     */
-    public function setUrls($urls) {
-        $this->urls = $urls;
     }
 }

--- a/RedePay/Order/Order.php
+++ b/RedePay/Order/Order.php
@@ -8,6 +8,7 @@ use RedePay\Item\Item;
 use RedePay\Settings\Settings;
 use RedePay\Shipping\Shipping;
 use RedePay\Url\Url;
+use RedePay\Utils\Fillable;
 
 /**
  * Class Order
@@ -20,7 +21,7 @@ class Order
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * The order ID

--- a/RedePay/Order/Order.php
+++ b/RedePay/Order/Order.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Order;
 
+/**
+ * Class Order
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Order {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Order/OrderBuilder.php
+++ b/RedePay/Order/OrderBuilder.php
@@ -1,8 +1,4 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Order;
 
@@ -12,6 +8,12 @@ use \RedePay\Item\Item;
 use \RedePay\History\History;
 use \RedePay\Order\Order;
 
+/**
+ * Class OrderBuilder
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 trait OrderBuilder {
     use \RedePay\Shipping\ShippingBuilder;
 

--- a/RedePay/Order/OrderBuilder.php
+++ b/RedePay/Order/OrderBuilder.php
@@ -14,45 +14,56 @@ use \RedePay\Order\Order;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-trait OrderBuilder {
+trait OrderBuilder
+{
+    /**
+     * Traits
+     */
     use \RedePay\Shipping\ShippingBuilder;
 
-    private function buildOrder($data) {
-        if(isset($data->orderId)) {
+    /**
+     * Factory an Order object
+     *
+     * @param \stdClass $data
+     * @return \RedePay\Order\Order
+     */
+    private function buildOrder($data)
+    {
+        if (isset($data->orderId)) {
             $data->id = $data->orderId;
         }
 
-        if(isset($data->createdAt)) {
+        if (isset($data->createdAt)) {
             $data->creationDate = $data->createdAt;
         }
 
-        if(isset($data->shipping)) {
+        if (isset($data->shipping)) {
             $data->shipping = new Shipping($this->buildShipping($data->shipping));
         }
 
-        if(isset($data->customer)) {
+        if (isset($data->customer)) {
             $data->customer = new Customer($data->customer);
         }
 
-        if(isset($data->items)) {
+        if (isset($data->items)) {
             foreach ($data->items as $key => $value) {
                 $data->items[$key] = new Item($value);
             }
         }
 
-        if(isset($data->statusHistory)) {
+        if (isset($data->statusHistory)) {
             foreach ($data->statusHistory as $key => $value) {
                 $data->statusHistory[$key] = new History($value);
             }
         }
 
-        if(isset($data->transactionHistory)) {
+        if (isset($data->transactionHistory)) {
             foreach ($data->transactionHistory as $key => $value) {
                 $data->transactionHistory[$key] = new History($value);
             }
         }
 
-        if(isset($data->reversalHistory)) {
+        if (isset($data->reversalHistory)) {
             foreach ($data->reversalHistory as $key => $value) {
                 $data->reversalHistory[$key] = new History($value);
             }

--- a/RedePay/Order/OrderBuilder.php
+++ b/RedePay/Order/OrderBuilder.php
@@ -2,11 +2,11 @@
 
 namespace RedePay\Order;
 
-use \RedePay\Shipping\Shipping;
-use \RedePay\Customer\Customer;
-use \RedePay\Item\Item;
-use \RedePay\History\History;
-use \RedePay\Order\Order;
+use RedePay\Customer\Customer;
+use RedePay\History\History;
+use RedePay\Item\Item;
+use RedePay\Shipping\Shipping;
+use RedePay\Shipping\ShippingBuilder;
 
 /**
  * Class OrderBuilder
@@ -19,7 +19,7 @@ trait OrderBuilder
     /**
      * Traits
      */
-    use \RedePay\Shipping\ShippingBuilder;
+    use ShippingBuilder;
 
     /**
      * Factory an Order object

--- a/RedePay/Order/OrderHandler.php
+++ b/RedePay/Order/OrderHandler.php
@@ -13,16 +13,34 @@ use \RedePay\Order\Request\OrderCreate;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class OrderHandler extends AbstractHandler {
+class OrderHandler extends AbstractHandler
+{
+    /**
+     * Traits
+     */
     use OrderBuilder;
 
-    public function get($orderId) {
+    /**
+     * Gets an Order
+     *
+     * @param string $orderId
+     * @return Order
+     */
+    public function get($orderId)
+    {
         $request = new OrderGet($orderId);
         $response = $this->client->send($request);
         return $this->buildOrder($response);
     }
 
-    public function create($order) {
+    /**
+     * Creates an Order
+     *
+     * @param Order $order
+     * @return Order
+     */
+    public function create(Order $order)
+    {
         $request = new OrderCreate($order);
         $response = $this->client->send($request);
         return $this->buildOrder($response);

--- a/RedePay/Order/OrderHandler.php
+++ b/RedePay/Order/OrderHandler.php
@@ -2,10 +2,9 @@
 
 namespace RedePay\Order;
 
-use \RedePay\Utils\Client;
-use \RedePay\Utils\AbstractHandler;
-use \RedePay\Order\Request\OrderGet;
-use \RedePay\Order\Request\OrderCreate;
+use RedePay\Order\Request\OrderGet;
+use RedePay\Order\Request\OrderCreate;
+use RedePay\Utils\AbstractHandler;
 
 /**
  * Class OrderHandler

--- a/RedePay/Order/OrderHandler.php
+++ b/RedePay/Order/OrderHandler.php
@@ -1,8 +1,4 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Order;
 
@@ -11,6 +7,12 @@ use \RedePay\Utils\AbstractHandler;
 use \RedePay\Order\Request\OrderGet;
 use \RedePay\Order\Request\OrderCreate;
 
+/**
+ * Class OrderHandler
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class OrderHandler extends AbstractHandler {
     use OrderBuilder;
 

--- a/RedePay/Order/Request/OrderCreate.php
+++ b/RedePay/Order/Request/OrderCreate.php
@@ -12,7 +12,7 @@ class OrderCreate implements RequestInterface {
 
 	public function getPayload() {
 		$reference = $this->order->getReference();
-		$discount = $this->order->getDiscount();
+		$discount = (int)number_format($this->order->getDiscount(),2,'','');
 		$settings = $this->handleSettings($this->order);
 		$customer = $this->handleCustomer($this->order);
 		$shipping = $this->handleShipping($this->order);
@@ -110,7 +110,7 @@ class OrderCreate implements RequestInterface {
 	}
 
 	private function handleShipping($order) {
-        $cost = $order->getShipping()->getCost();
+        $cost = (int)number_format($order->getShipping()->getCost(),2,'','');
         $address = $this->handleAddress($order);
 
         $parameters = array(
@@ -133,11 +133,11 @@ class OrderCreate implements RequestInterface {
 		foreach ($order->getItems() as $key => $item) {
 			$items[$key] = array(
 				"id" => $item->getId(),
-				"amount" => $item->getAmount(),
+				"amount" => (int)number_format($item->getAmount(),2,'',''),
 				"quantity" => $item->getQuantity(),
-				"discount" => $item->getDiscount(),
+				"discount" => (int)number_format($item->getDiscount(),2,'',''),
 				"description" => $item->getDescription(),
-				"freight" => $item->getFreight()
+				"freight" => (int)number_format($item->getFreight(),2,'',''),
 			);
 
 			if(!$item->getDiscount() || $item->getDiscount() == 0) {

--- a/RedePay/Order/Request/OrderCreate.php
+++ b/RedePay/Order/Request/OrderCreate.php
@@ -2,6 +2,7 @@
 
 namespace RedePay\Order\Request;
 
+use RedePay\Order\Order;
 use \RedePay\Utils\RequestInterface;
 
 /**
@@ -10,68 +11,109 @@ use \RedePay\Utils\RequestInterface;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class OrderCreate implements RequestInterface {
-	private $order;
+class OrderCreate implements RequestInterface
+{
+    /**
+     * The Order instance
+     *
+     * @var Order
+     */
+    private $order;
 
-	public function __construct($order) {
-		$this->order = $order;
-	}
+    /**
+     * OrderCreate constructor.
+     *
+     * @param Order $order
+     */
+    public function __construct(Order $order)
+    {
+        $this->order = $order;
+    }
 
-	public function getPayload() {
-		$reference = $this->order->getReference();
-		$discount = (int)number_format($this->order->getDiscount(),2,'','');
-		$settings = $this->handleSettings($this->order);
-		$customer = $this->handleCustomer($this->order);
-		$shipping = $this->handleShipping($this->order);
-		$items = $this->handleItems($this->order);
-		$urls = $this->handleUrls($this->order);
-		
-		$parameters = array(
-			"reference" => $reference,
-			"discount" => $discount,
-			"settings" => $settings,
-			"customer" => $customer,
-			"shipping" => $shipping,
-			"items" => $items,
-			"urls" => $urls
-		);
+    /**
+     * {@inheritdoc}
+     */
+    public function getPayload()
+    {
+        $reference = $this->order->getReference();
+        $discount = (int)number_format($this->order->getDiscount(), 2, '', '');
+        $settings = $this->handleSettings($this->order);
+        $customer = $this->handleCustomer($this->order);
+        $shipping = $this->handleShipping($this->order);
+        $items = $this->handleItems($this->order);
+        $urls = $this->handleUrls($this->order);
+        
+        $parameters = array(
+            "reference" => $reference,
+            "discount" => $discount,
+            "settings" => $settings,
+            "customer" => $customer,
+            "shipping" => $shipping,
+            "items" => $items,
+            "urls" => $urls
+        );
 
-		if(!$discount || $discount == 0) {
-			unset($parameters["discount"]);
-		}
+        if (!$discount || $discount == 0) {
+            unset($parameters["discount"]);
+        }
 
-		if(empty($customer)) {
-			unset($parameters["customer"]);
-		}
+        if (empty($customer)) {
+            unset($parameters["customer"]);
+        }
 
-		if(empty($shipping)) {
-			unset($parameters["shipping"]);
-		}
+        if (empty($shipping)) {
+            unset($parameters["shipping"]);
+        }
 
-		if(empty($urls)) {
-			unset($parameters["urls"]);
-		}
-		return json_encode($parameters, JSON_UNESCAPED_UNICODE);
-	}
+        if (empty($urls)) {
+            unset($parameters["urls"]);
+        }
+        return json_encode($parameters, JSON_UNESCAPED_UNICODE);
+    }
 
-	public function getPath() {
-		return sprintf("%s/orders", $this->getApiUrl());
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return sprintf("%s/orders", $this->getApiUrl());
+    }
 
-	public function getData() {
-		return null;
-	}
+    /**
+     * Gets the data
+     *
+     * @return null
+     */
+    public function getData()
+    {
+        return null;
+    }
 
-	public function getMethod() {
-		return self::HTTP_POST;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethod()
+    {
+        return self::HTTP_POST;
+    }
 
-	public function getApiUrl() {
-		return self::API_URL;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiUrl()
+    {
+        return self::API_URL;
+    }
 
-	private function handleCustomer($order) {
-        if($order->getCustomer()) {
+    /**
+     * Parses the Customer object
+     *
+     * @param Order $order
+     * @return array
+     */
+    private function handleCustomer(Order $order)
+    {
+        if ($order->getCustomer()) {
             $name = $order->getCustomer()->getName();
             $email = $order->getCustomer()->getEmail();
             $documents = $this->handleDocuments($order);
@@ -84,11 +126,20 @@ class OrderCreate implements RequestInterface {
                 "phones" => $phones
             );
             return $parameters;
+        } else {
+            // TODO: throw exception
         }
-	}
+    }
 
-	private function handleSettings($order) {
-        if($order->getSettings()) {
+    /**
+     * Parses the Settings object
+     *
+     * @param Order $order
+     * @return array
+     */
+    private function handleSettings(Order $order)
+    {
+        if ($order->getSettings()) {
             $expiresAt = $order->getSettings()->getExpiresAt();
             $maxInstallments = $order->getSettings()->getMaxInstallments();
             $attempts = $order->getSettings()->getAttempts();
@@ -101,23 +152,32 @@ class OrderCreate implements RequestInterface {
                 "shoppingCartRecovery" => $shoppingCartRecovery
             );
 
-            if(!$expiresAt) {
+            if (!$expiresAt) {
                 unset($parameters["expiresAt"]);
             }
 
-            if(!$attempts) {
+            if (!$attempts) {
                 unset($parameters["attempts"]);
             }
 
-            if(empty($shoppingCartRecovery)) {
+            if (empty($shoppingCartRecovery)) {
                 unset($parameters["shoppingCartRecovery"]);
             }
             return $parameters;
+        } else {
+            // TODO: throws exception
         }
-	}
+    }
 
-	private function handleShipping($order) {
-        $cost = (int)number_format($order->getShipping()->getCost(),2,'','');
+    /**
+     * Parses the Shipping object
+     *
+     * @param Order $order
+     * @return array
+     */
+    private function handleShipping(Order $order)
+    {
+        $cost = (int)number_format($order->getShipping()->getCost(), 2, '', '');
         $address = $this->handleAddress($order);
 
         $parameters = array(
@@ -125,41 +185,56 @@ class OrderCreate implements RequestInterface {
             "address" => $address
         );
 
-        if(!$cost || $cost == 0) {
+        if (!$cost || $cost == 0) {
             unset($parameters["cost"]);
         }
 
-        if(empty($address)) {
+        if (empty($address)) {
             unset($parameters["address"]);
         }
+
         return $parameters;
-	}
+    }
 
-	private function handleItems($order) {
-		$items = array();
-		foreach ($order->getItems() as $key => $item) {
-			$items[$key] = array(
-				"id" => $item->getId(),
-				"amount" => (int)number_format($item->getAmount(),2,'',''),
-				"quantity" => $item->getQuantity(),
-				"discount" => (int)number_format($item->getDiscount(),2,'',''),
-				"description" => $item->getDescription(),
-				"freight" => (int)number_format($item->getFreight(),2,'',''),
-			);
+    /**
+     * Parses the Item objects
+     *
+     * @param Order $order
+     * @return array
+     */
+    private function handleItems(Order $order)
+    {
+        $items = array();
+        foreach ($order->getItems() as $key => $item) {
+            $items[$key] = array(
+                "id" => $item->getId(),
+                "amount" => (int)number_format($item->getAmount(), 2, '', ''),
+                "quantity" => $item->getQuantity(),
+                "discount" => (int)number_format($item->getDiscount(), 2, '', ''),
+                "description" => $item->getDescription(),
+                "freight" => (int)number_format($item->getFreight(), 2, '', ''),
+            );
 
-			if(!$item->getDiscount() || $item->getDiscount() == 0) {
-				unset($items[$key]["discount"]);
-			}
+            if (!$item->getDiscount() || $item->getDiscount() == 0) {
+                unset($items[$key]["discount"]);
+            }
 
-			if(!$item->getFreight() || $item->getFreight() == 0) {
-				unset($items[$key]["freight"]);
-			}
-		}
-		return $items;
-	}
+            if (!$item->getFreight() || $item->getFreight() == 0) {
+                unset($items[$key]["freight"]);
+            }
+        }
+        return $items;
+    }
 
-	private function handleUrls($order) {
-        if($order->getUrls()) {
+    /**
+     * Parses the Url objects
+     *
+     * @param Order $order
+     * @return array
+     */
+    private function handleUrls(Order $order)
+    {
+        if ($order->getUrls()) {
             $urls = array();
             foreach ($order->getUrls() as $key => $url) {
                 $urls[$key] = array(
@@ -168,102 +243,132 @@ class OrderCreate implements RequestInterface {
                 );
             }
             return $urls;
+        } else {
+            // TODO: throws exception
         }
-	}
+    }
 
-	private function handleAddress($order) {
-		$alias = $order->getShipping()->getAddress()->getAlias();
-		$street = $order->getShipping()->getAddress()->getStreet();
-		$number = $order->getShipping()->getAddress()->getNumber();
-		$complement = $order->getShipping()->getAddress()->getComplement();
-		$postalCode = $order->getShipping()->getAddress()->getPostalCode();
-		$district = $order->getShipping()->getAddress()->getDistrict();
-		$city = $order->getShipping()->getAddress()->getCity();
-		$state = $order->getShipping()->getAddress()->getState();
+    /**
+     * Parses the Address object
+     *
+     * @param Order $order
+     * @return array
+     */
+    private function handleAddress(Order $order)
+    {
+        $alias = $order->getShipping()->getAddress()->getAlias();
+        $street = $order->getShipping()->getAddress()->getStreet();
+        $number = $order->getShipping()->getAddress()->getNumber();
+        $complement = $order->getShipping()->getAddress()->getComplement();
+        $postalCode = $order->getShipping()->getAddress()->getPostalCode();
+        $district = $order->getShipping()->getAddress()->getDistrict();
+        $city = $order->getShipping()->getAddress()->getCity();
+        $state = $order->getShipping()->getAddress()->getState();
 
-		$parameters = array(
-			"alias" => $alias,
-			"street" => $street,
-			"number" => $number,
-			"complement" => $complement,
-			"postalCode" => $postalCode,
-			"district" => $district,
-			"city" => $city,
-			"state" => $state
-		);
+        $parameters = array(
+            "alias" => $alias,
+            "street" => $street,
+            "number" => $number,
+            "complement" => $complement,
+            "postalCode" => $postalCode,
+            "district" => $district,
+            "city" => $city,
+            "state" => $state
+        );
 
-		if(!$alias) {
-			unset($parameters["alias"]);
-		}
+        if (!$alias) {
+            unset($parameters["alias"]);
+        }
 
-		if(!$complement) {
-			unset($parameters["complement"]);
-		}
-		return $parameters;
-	}
+        if (!$complement) {
+            unset($parameters["complement"]);
+        }
+        return $parameters;
+    }
 
-	private function handleShoppingCartRecovery($order) {
-		$enable = $order->getSettings()->getShoppingCartRecovery()->getEnable();
-		$firstAlert = $order->getSettings()->getShoppingCartRecovery()->getFirstAlert();
-		$secondAlert = $order->getSettings()->getShoppingCartRecovery()->getSecondAlert();
-		$thirdAlert = $order->getSettings()->getShoppingCartRecovery()->getThirdAlert();
-		$fourthAlert = $order->getSettings()->getShoppingCartRecovery()->getFourthAlert();
-		$logoUrl = $order->getSettings()->getShoppingCartRecovery()->getLogoUrl();
+    /**
+     * Parses the ShoppingCartRecovery object
+     *
+     * @param Order $order
+     * @return array
+     */
+    private function handleShoppingCartRecovery(Order $order)
+    {
+        $enable = $order->getSettings()->getShoppingCartRecovery()->getEnable();
+        $firstAlert = $order->getSettings()->getShoppingCartRecovery()->getFirstAlert();
+        $secondAlert = $order->getSettings()->getShoppingCartRecovery()->getSecondAlert();
+        $thirdAlert = $order->getSettings()->getShoppingCartRecovery()->getThirdAlert();
+        $fourthAlert = $order->getSettings()->getShoppingCartRecovery()->getFourthAlert();
+        $logoUrl = $order->getSettings()->getShoppingCartRecovery()->getLogoUrl();
 
-		$parameters = array(
-			"enable" => $enable,
-			"firstAlert" => $firstAlert,
-			"secondAlert" => $secondAlert,
-			"thirdAlert" => $thirdAlert,
-			"fourthAlert" => $fourthAlert,
-			"logoUrl" => $logoUrl
-		);
+        $parameters = array(
+            "enable" => $enable,
+            "firstAlert" => $firstAlert,
+            "secondAlert" => $secondAlert,
+            "thirdAlert" => $thirdAlert,
+            "fourthAlert" => $fourthAlert,
+            "logoUrl" => $logoUrl
+        );
 
-		if(!$enable) {
-			unset($parameters["enable"]);
-		}
+        if (!$enable) {
+            unset($parameters["enable"]);
+        }
 
-		if(!$firstAlert) {
-			unset($parameters["firstAlert"]);
-		}
+        if (!$firstAlert) {
+            unset($parameters["firstAlert"]);
+        }
 
-		if(!$secondAlert) {
-			unset($parameters["secondAlert"]);
-		}
+        if (!$secondAlert) {
+            unset($parameters["secondAlert"]);
+        }
 
-		if(!$thirdAlert) {
-			unset($parameters["thirdAlert"]);
-		}
+        if (!$thirdAlert) {
+            unset($parameters["thirdAlert"]);
+        }
 
-		if(!$fourthAlert) {
-			unset($parameters["fourthAlert"]);
-		}
+        if (!$fourthAlert) {
+            unset($parameters["fourthAlert"]);
+        }
 
-		if(!$logoUrl) {
-			unset($parameters["logoUrl"]);
-		}
-		return $parameters;
-	}
+        if (!$logoUrl) {
+            unset($parameters["logoUrl"]);
+        }
+        return $parameters;
+    }
 
-	private function handlePhones($order) {
-		$phones = array();
-		foreach ($order->getCustomer()->getPhones() as $key => $phone) {
-			$phones[$key] = array(
-				"kind" => $phone->getKind(),
-				"number" => $phone->getNumber()
-			);
-		}
-		return $phones;
-	}
+    /**
+     * Parses the Phone objects
+     *
+     * @param Order $order
+     * @return array
+     */
+    private function handlePhones(Order $order)
+    {
+        $phones = array();
+        foreach ($order->getCustomer()->getPhones() as $key => $phone) {
+            $phones[$key] = array(
+                "kind" => $phone->getKind(),
+                "number" => $phone->getNumber()
+            );
+        }
+        return $phones;
+    }
 
-	private function handleDocuments($order) {
-		$documents = array();
-		foreach ($order->getCustomer()->getDocuments() as $key => $document) {
-			$documents[$key] = array(
-				"kind" => $document->getKind(),
-				"number" => $document->getNumber()
-			);
-		}
-		return $documents;
-	}
+    /**
+     * Parses the Document objects
+     *
+     * @param Order $order
+     * @return array
+     */
+    private function handleDocuments(Order $order)
+    {
+        $documents = array();
+        foreach ($order->getCustomer()->getDocuments() as $key => $document) {
+            $documents[$key] = array(
+                "kind" => $document->getKind(),
+                "number" => $document->getNumber()
+            );
+        }
+        return $documents;
+    }
 }

--- a/RedePay/Order/Request/OrderCreate.php
+++ b/RedePay/Order/Request/OrderCreate.php
@@ -3,7 +3,7 @@
 namespace RedePay\Order\Request;
 
 use RedePay\Order\Order;
-use \RedePay\Utils\RequestInterface;
+use RedePay\Utils\RequestInterface;
 
 /**
  * Class OrderCreate

--- a/RedePay/Order/Request/OrderCreate.php
+++ b/RedePay/Order/Request/OrderCreate.php
@@ -1,8 +1,15 @@
 <?php
+
 namespace RedePay\Order\Request;
 
 use \RedePay\Utils\RequestInterface;
 
+/**
+ * Class OrderCreate
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class OrderCreate implements RequestInterface {
 	private $order;
 

--- a/RedePay/Order/Request/OrderGet.php
+++ b/RedePay/Order/Request/OrderGet.php
@@ -10,34 +10,74 @@ use \RedePay\Utils\RequestInterface;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class OrderGet implements RequestInterface {
-	private $orderId;
+class OrderGet implements RequestInterface
+{
+    /**
+     * The order ID
+     *
+     * @var string
+     */
+    private $orderId;
 
-	public function __construct($orderId) {
-		$this->orderId = $orderId;
-	}
+    /**
+     * OrderGet constructor.
+     *
+     * @param string $orderId The order ID
+     */
+    public function __construct($orderId)
+    {
+        $this->orderId = $orderId;
+    }
 
-	public function getPayload() {
-		return [];
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getPayload()
+    {
+        return [];
+    }
 
-	public function getPath() {
-		return sprintf("%s/orders/%s", $this->getApiUrl(), $this->getOrderId());
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return sprintf("%s/orders/%s", $this->getApiUrl(), $this->getOrderId());
+    }
 
-	public function getOrderId() {
-		return $this->orderId;
-	}
+    /**
+     * Gets the order ID
+     *
+     * @return string
+     */
+    public function getOrderId()
+    {
+        return $this->orderId;
+    }
 
-	public function getData() {
-		return null;
-	}
+    /**
+     * Gets the data
+     *
+     * @return null
+     */
+    public function getData()
+    {
+        return null;
+    }
 
-	public function getMethod() {
-		return self::HTTP_GET;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethod()
+    {
+        return self::HTTP_GET;
+    }
 
-	public function getApiUrl() {
-		return self::API_URL;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiUrl()
+    {
+        return self::API_URL;
+    }
 }

--- a/RedePay/Order/Request/OrderGet.php
+++ b/RedePay/Order/Request/OrderGet.php
@@ -2,7 +2,7 @@
 
 namespace RedePay\Order\Request;
 
-use \RedePay\Utils\RequestInterface;
+use RedePay\Utils\RequestInterface;
 
 /**
  * Class OrderGet

--- a/RedePay/Order/Request/OrderGet.php
+++ b/RedePay/Order/Request/OrderGet.php
@@ -1,8 +1,15 @@
 <?php
+
 namespace RedePay\Order\Request;
 
 use \RedePay\Utils\RequestInterface;
 
+/**
+ * Class OrderGet
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class OrderGet implements RequestInterface {
 	private $orderId;
 

--- a/RedePay/Payment/Payment.php
+++ b/RedePay/Payment/Payment.php
@@ -8,51 +8,73 @@ namespace RedePay\Payment;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Payment {
+class Payment
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * The method
+     *
+     * @var string
      */
     private $method;
 
     /**
-     * @param String
+     * The card brand
+     *
+     * @var string
      */
     private $cardBrand;
 
     /**
-     * @param String
+     * The installments number
+     *
+     * @var int
      */
     private $installments;
 
     /**
-     * @param Payment
+     * Payment constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Payment object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @param String
+     * Gets the method
+     *
+     * @return string
      */
-    public function getMethod() {
+    public function getMethod()
+    {
         return $this->method;
     }
 
     /**
-     * @param String
+     * Gets the card brand
+     *
+     * @return string
      */
-    public function getCardBrand() {
+    public function getCardBrand()
+    {
         return $this->cardBrand;
     }
 
     /**
-     * @return String
+     * Gets the installments number
+     * w
+     * @return int
      */
-    public function getInstallments() {
+    public function getInstallments()
+    {
         return $this->installments;
     }
 }

--- a/RedePay/Payment/Payment.php
+++ b/RedePay/Payment/Payment.php
@@ -2,6 +2,8 @@
 
 namespace RedePay\Payment;
 
+use RedePay\Utils\Fillable;
+
 /**
  * Class Payment
  *
@@ -13,7 +15,7 @@ class Payment
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * The method

--- a/RedePay/Payment/Payment.php
+++ b/RedePay/Payment/Payment.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Payment;
 
+/**
+ * Class Payment
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Payment {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Phone/Phone.php
+++ b/RedePay/Phone/Phone.php
@@ -2,6 +2,9 @@
 
 namespace RedePay\Phone;
 
+use RedePay\Utils\Fillable;
+use RedePay\Utils\RemoveMask;
+
 /**
  * Class Phone
  *
@@ -13,8 +16,8 @@ class Phone
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
-    use \RedePay\Utils\RemoveMask;
+    use Fillable;
+    use RemoveMask;
 
     /**
      * Enum constants

--- a/RedePay/Phone/Phone.php
+++ b/RedePay/Phone/Phone.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Phone;
 
+/**
+ * Class Phone
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Phone {
     use \RedePay\Utils\Fillable;
     use \RedePay\Utils\RemoveMask;

--- a/RedePay/Phone/Phone.php
+++ b/RedePay/Phone/Phone.php
@@ -8,54 +8,90 @@ namespace RedePay\Phone;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Phone {
+class Phone
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
     use \RedePay\Utils\RemoveMask;
 
     /**
-     * @param String
+     * Enum constants
+     */
+    const KIND_COMMERCIAL = 'business';
+    const KIND_HOME       = 'home';
+    const KIND_MOBILE     = 'cellphone';
+
+    /**
+     * The phone type
+     *
+     * @var string
      */
     private $kind;
 
     /**
-     * @param String
+     * The phone number
+     *
+     * @var string
      */
     private $number;
 
     /**
-     * @param Phone
+     * Phone constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Phone object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Sets the type
+     *
+     * @param string $kind
+     * @return Phone
      */
-    public function getKind() {
+    public function setKind($kind)
+    {
+        $this->kind = $kind;
+
+        return $this;
+    }
+
+    /**
+     * Gets the type
+     *
+     * @return string
+     */
+    public function getKind()
+    {
         return $this->kind;
     }
 
     /**
-     * @return String
+     * Sets the number
+     *
+     * @param string $number
+     * @return Phone
      */
-    public function getNumber() {
-        return $this->number;
-    }
-
-    /**
-     * @param String
-     */
-    public function setKind($kind) {
-        $this->kind = $kind;
-    }
-
-    /**
-     * @param String
-     */
-    public function setNumber($number) {
+    public function setNumber($number)
+    {
         $this->number = $this->removeMask($number);
+
+        return $this;
+    }
+
+    /**
+     * Gets the number
+     *
+     * @return string
+     */
+    public function getNumber()
+    {
+        return $this->number;
     }
 }

--- a/RedePay/RedePay.php
+++ b/RedePay/RedePay.php
@@ -2,10 +2,10 @@
 
 namespace RedePay;
 
-use \RedePay\Utils\Client;
-use \RedePay\Transaction\TransactionHandler;
-use \RedePay\Order\OrderHandler;
-use \RedePay\Tracking\TrackingHandler;
+use RedePay\Order\OrderHandler;
+use RedePay\Tracking\TrackingHandler;
+use RedePay\Transaction\TransactionHandler;
+use RedePay\Utils\Client;
 
 /**
  * Class RedePay

--- a/RedePay/RedePay.php
+++ b/RedePay/RedePay.php
@@ -1,8 +1,4 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay;
 
@@ -11,6 +7,12 @@ use \RedePay\Transaction\TransactionHandler;
 use \RedePay\Order\OrderHandler;
 use \RedePay\Tracking\TrackingHandler;
 
+/**
+ * Class RedePay
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class RedePay {
     /**
      * @param Client

--- a/RedePay/RedePay.php
+++ b/RedePay/RedePay.php
@@ -13,38 +13,53 @@ use \RedePay\Tracking\TrackingHandler;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class RedePay {
+class RedePay
+{
     /**
-     * @param Client
+     * The API Client
+     *
+     * @var Client
      */
     private $client;
 
     /**
-     * @param TransactionHandler
+     * The transaction handler
+     *
+     * @var TransactionHandler
      */
     private $transactionHandler;
 
     /**
-     * @param OrderHandler
+     * The order handler
+     *
+     * @var OrderHandler
      */
     private $orderHandler;
 
     /**
-     * @param TrackingHandler
+     * The tracking handler
+     *
+     * @var TrackingHandler
      */
     private $trackingHandler;
 
     /**
-     * @param String
+     * RedePay constructor.
+     *
+     * @param string $apiKey
      */
-    public function __construct($apiKey) {
+    public function __construct($apiKey)
+    {
         $this->client = new Client($apiKey);
     }
 
     /**
+     * Gets the transaction handler
+     *
      * @return TransactionHandler
      */
-    public function transaction() {
+    public function transaction()
+    {
         if (!$this->transactionHandler instanceof TransactionHandler) {
             $this->transactionHandler = new TransactionHandler($this->client);
         }
@@ -52,9 +67,12 @@ class RedePay {
     }
 
     /**
+     * Gets the order handler
+     *
      * @return OrderHandler
      */
-    public function order() {
+    public function order()
+    {
         if (!$this->orderHandler instanceof OrderHandler) {
             $this->orderHandler = new OrderHandler($this->client);
         }
@@ -62,9 +80,12 @@ class RedePay {
     }
 
     /**
+     * Gets the tracking handler
+     *
      * @return TrackingHandler
      */
-    public function tracking() {
+    public function tracking()
+    {
         if (!$this->trackingHandler instanceof TrackingHandler) {
             $this->trackingHandler = new TrackingHandler($this->client);
         }

--- a/RedePay/Settings/Settings.php
+++ b/RedePay/Settings/Settings.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Settings;
 
+/**
+ * Class Settings
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Settings {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Settings/Settings.php
+++ b/RedePay/Settings/Settings.php
@@ -3,6 +3,7 @@
 namespace RedePay\Settings;
 
 use RedePay\ShoppingCartRecovery\ShoppingCartRecovery;
+use RedePay\Utils\Fillable;
 
 /**
  * Class Settings
@@ -15,7 +16,7 @@ class Settings
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * The expiration date

--- a/RedePay/Settings/Settings.php
+++ b/RedePay/Settings/Settings.php
@@ -2,94 +2,150 @@
 
 namespace RedePay\Settings;
 
+use RedePay\ShoppingCartRecovery\ShoppingCartRecovery;
+
 /**
  * Class Settings
  *
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Settings {
+class Settings
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * The expiration date
+     *
+     * @var string
      */
     private $expiresAt;
 
     /**
-     * @param String
+     * The number of maximum installments allowed
+     *
+     * @var int
      */
     private $maxInstallments;
 
     /**
-     * @param String
+     * The maximum number of payment attempts
+     *
+     * @var int
      */
     private $attempts;
 
     /**
-     * @param ShoppingCartRecovery
+     * The ShoppingCartRecovery object
+     *
+     * @var ShoppingCartRecovery
      */
     private $shoppingCartRecovery;
 
     /**
-     * @param Settings
+     * Settings constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Settings object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Sets the expiration date
+     *
+     * @param string $expiresAt
+     * @return Settings
      */
-    public function getExpiresAt() {
+    public function setExpiresAt($expiresAt)
+    {
+        $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+
+    /**
+     * Gets the expiration date
+     *
+     * @return string
+     */
+    public function getExpiresAt()
+    {
         return $this->expiresAt;
     }
 
     /**
-     * @return String
+     * Sets the maximum installments number
+     *
+     * @param int $maxInstallments
+     * @return Settings
      */
-    public function getMaxInstallments() {
+    public function setMaxInstallments($maxInstallments)
+    {
+        $this->maxInstallments = $maxInstallments;
+
+        return $this;
+    }
+
+    /**
+     * Gets the maximum installments number
+     *
+     * @return int
+     */
+    public function getMaxInstallments()
+    {
         return $this->maxInstallments;
     }
 
-    public function getAttempts() {
+    /**
+     * Sets the maximum payment attempts
+     *
+     * @param int $attempts
+     * @return Settings
+     */
+    public function setAttempts($attempts)
+    {
+        $this->attempts = $attempts;
+
+        return $this;
+    }
+
+    /**
+     * Gets the maximum payment attempts
+     *
+     * @return int
+     */
+    public function getAttempts()
+    {
         return $this->attempts;
     }
 
     /**
-     * @return String
+     * Sets the ShoppingCartRecovery object
+     *
+     * @param ShoppingCartRecovery $shoppingCartRecovery
+     * @return Settings
      */
-    public function getShoppingCartRecovery() {
-        return $this->shoppingCartRecovery;
-    }
-
-    /**
-     * @param String
-     */
-    public function setExpiresAt($expiresAt) {
-        $this->expiresAt = $expiresAt;
-    }
-
-    /**
-     * @param String
-     */
-    public function setMaxInstallments($maxInstallments) {
-        $this->maxInstallments = $maxInstallments;
-    }
-
-    /**
-     * @param String
-     */
-    public function setAttempts($attempts) {
-        $this->attempts = $attempts;
-    }
-
-    /**
-     * @param ShoppingCartRecovery
-     */
-    public function setShoppingCartRecovery($shoppingCartRecovery) {
+    public function setShoppingCartRecovery(ShoppingCartRecovery $shoppingCartRecovery)
+    {
         $this->shoppingCartRecovery = $shoppingCartRecovery;
+
+        return $this;
+    }
+
+    /**
+     * Gets the ShoppingCartRecovery object
+     *
+     * @return ShoppingCartRecovery
+     */
+    public function getShoppingCartRecovery()
+    {
+        return $this->shoppingCartRecovery;
     }
 }

--- a/RedePay/Shipping/Shipping.php
+++ b/RedePay/Shipping/Shipping.php
@@ -2,71 +2,102 @@
 
 namespace RedePay\Shipping;
 
+use RedePay\Address\Address;
+
 /**
  * Class Shipping
  *
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Shipping {
+class Shipping
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param Address
+     * The shipping address
+     *
+     * @var Address
      */
     private $address;
 
     /**
-     * @param String
+     * The shipping cost
+     *
+     * @var float|int
      */
     private $cost;
 
     /**
-     * @param String
+     * The shipping tracking number
+     *
+     * @var string
      */
     private $trackingNumber;
 
-    /**
-     * @param Shipping
-     */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
+     * Sets the address
+     *
+     * @param Address $address
+     * @return Shipping
+     */
+    public function setAddress(Address $address)
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    /**
+     * Gets the address
+     *
      * @return Address
      */
-    public function getAddress() {
+    public function getAddress()
+    {
         return $this->address;
     }
 
     /**
-     * @return String
+     * Sets the cost
+     *
+     * @param float|int $cost
+     * @return Shipping
      */
-    public function getCost() {
+    public function setCost($cost)
+    {
+        $this->cost = $cost;
+
+        return $this;
+    }
+
+    /**
+     * Gets the cost
+     *
+     * @return float|int
+     */
+    public function getCost()
+    {
         return $this->cost;
     }
 
     /**
-     * @return String
+     * Gets the tracking number
+     *
+     * @return string
      */
-    public function getTrackingNumber() {
+    public function getTrackingNumber()
+    {
         return $this->trackingNumber;
-    }
-
-    /**
-     * @param String
-     */
-    public function setAddress($address) {
-        $this->address = $address;
-    }
-
-    /**
-     * @param String
-     */
-    public function setCost($cost) {
-        $this->cost = $cost;
     }
 }

--- a/RedePay/Shipping/Shipping.php
+++ b/RedePay/Shipping/Shipping.php
@@ -3,6 +3,7 @@
 namespace RedePay\Shipping;
 
 use RedePay\Address\Address;
+use RedePay\Utils\Fillable;
 
 /**
  * Class Shipping
@@ -15,7 +16,7 @@ class Shipping
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * The shipping address

--- a/RedePay/Shipping/Shipping.php
+++ b/RedePay/Shipping/Shipping.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Shipping;
 
+/**
+ * Class Shipping
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Shipping {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Shipping/ShippingBuilder.php
+++ b/RedePay/Shipping/ShippingBuilder.php
@@ -11,8 +11,16 @@ use \RedePay\Shipping\Shipping;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-trait ShippingBuilder {
-    private function buildShipping($data) {
+trait ShippingBuilder
+{
+    /**
+     * Factory a shipping object
+     *
+     * @param \stdClass $data
+     * @return \RedePay\Shipping\Shipping
+     */
+    private function buildShipping($data)
+    {
         $data->address = new Address(get_object_vars($data->address));
         return new Shipping(get_object_vars($data));
     }

--- a/RedePay/Shipping/ShippingBuilder.php
+++ b/RedePay/Shipping/ShippingBuilder.php
@@ -2,8 +2,7 @@
 
 namespace RedePay\Shipping;
 
-use \RedePay\Address\Address;
-use \RedePay\Shipping\Shipping;
+use RedePay\Address\Address;
 
 /**
  * Class ShippingBuilder

--- a/RedePay/Shipping/ShippingBuilder.php
+++ b/RedePay/Shipping/ShippingBuilder.php
@@ -1,14 +1,16 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Shipping;
 
 use \RedePay\Address\Address;
 use \RedePay\Shipping\Shipping;
 
+/**
+ * Class ShippingBuilder
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 trait ShippingBuilder {
     private function buildShipping($data) {
         $data->address = new Address(get_object_vars($data->address));

--- a/RedePay/ShoppingCartRecovery/ShoppingCartRecovery.php
+++ b/RedePay/ShoppingCartRecovery/ShoppingCartRecovery.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\ShoppingCartRecovery;
 
+/**
+ * Class ShoppingCartRecovery
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class ShoppingCartRecovery {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/ShoppingCartRecovery/ShoppingCartRecovery.php
+++ b/RedePay/ShoppingCartRecovery/ShoppingCartRecovery.php
@@ -2,6 +2,8 @@
 
 namespace RedePay\ShoppingCartRecovery;
 
+use RedePay\Utils\Fillable;
+
 /**
  * Class ShoppingCartRecovery
  *
@@ -13,7 +15,7 @@ class ShoppingCartRecovery
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * Sets the recovery to enabled

--- a/RedePay/ShoppingCartRecovery/ShoppingCartRecovery.php
+++ b/RedePay/ShoppingCartRecovery/ShoppingCartRecovery.php
@@ -8,129 +8,202 @@ namespace RedePay\ShoppingCartRecovery;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class ShoppingCartRecovery {
+class ShoppingCartRecovery
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * Sets the recovery to enabled
+     *
+     * @var bool
      */
     private $enable;
 
     /**
-     * @param String
+     * Sets the first alarm in hours
+     *
+     * @var int
      */
     private $firstAlert;
 
     /**
-     * @param String
+     * Sets the second alarm in hours
+     *
+     * @var int
      */
     private $secondAlert;
 
     /**
-     * @param String
+     * Sets the third alarm in hours
+     *
+     * @var int
      */
     private $thirdAlert;
 
     /**
-     * @param String
+     * Sets the fourth alarm in hours
+     *
+     * @var int
      */
     private $fourthAlert;
 
     /**
-     * @param String
+     * The merchant logo url
+     *
+     * @var string
      */
     private $logoUrl;
 
     /**
-     * @param ShoppingCartRecovery
+     * ShoppingCartRecovery constructor.
+     *
+     * @param array|null $data The default data to be filled in the current ShoppingCartRecovery object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Sets the object enabled
+     *
+     * @param bool $enable
+     * @return ShoppingCartRecovery
      */
-    public function getEnable() {
+    public function setEnable($enable)
+    {
+        $this->enable = $enable;
+
+        return $this;
+    }
+
+    /**
+     * Gets the enabled status
+     *
+     * @return bool
+     */
+    public function getEnable()
+    {
         return $this->enable;
     }
 
     /**
-     * @return String
+     * Sets the first alert
+     *
+     * @param int $firstAlert
+     * @return ShoppingCartRecovery
      */
-    public function getFirstAlert() {
+    public function setFirstAlert($firstAlert)
+    {
+        $this->firstAlert = $firstAlert;
+
+        return $this;
+    }
+
+    /**
+     * Gets the first alert
+     *
+     * @return int
+     */
+    public function getFirstAlert()
+    {
         return $this->firstAlert;
     }
 
     /**
-     * @return String
+     * Sets the second alert
+     *
+     * @param int $secondAlert
+     * @return ShoppingCartRecovery
      */
-    public function getSecondAlert() {
+    public function setSecondAlert($secondAlert)
+    {
+        $this->secondAlert = $secondAlert;
+
+        return $this;
+    }
+
+    /**
+     * Gets the second alert
+     *
+     * @return int
+     */
+    public function getSecondAlert()
+    {
         return $this->secondAlert;
     }
 
     /**
-     * @return String
+     * Sets the third alert
+     *
+     * @param int $thirdAlert
+     * @return ShoppingCartRecovery
      */
-    public function getThirdAlert() {
+    public function setThirdAlert($thirdAlert)
+    {
+        $this->thirdAlert = $thirdAlert;
+
+        return $this;
+    }
+
+    /**
+     * Gets the third alert
+     *
+     * @return int
+     */
+    public function getThirdAlert()
+    {
         return $this->thirdAlert;
     }
 
     /**
-     * @return String
+     * Sets the fourth alert
+     *
+     * @param int $fourthAlert
+     * @return ShoppingCartRecovery
      */
-    public function getFourthAlert() {
+    public function setFourthAlert($fourthAlert)
+    {
+        $this->fourthAlert = $fourthAlert;
+
+        return $this;
+    }
+
+    /**
+     * Gets the fourth alert
+     *
+     * @return int
+     */
+    public function getFourthAlert()
+    {
         return $this->fourthAlert;
     }
 
     /**
-     * @return String
+     * Sets the logo url
+     *
+     * @param string $logoUrl
+     * @return ShoppingCartRecovery
      */
-    public function getLogoUrl() {
-        return $this->logoUrl;
-    }
-
-    /**
-     * @param String
-     */
-    public function setEnable($enable) {
-        $this->enable = $enable;
-    }
-
-    /**
-     * @param String
-     */
-    public function setFirstAlert($firstAlert) {
-        $this->firstAlert = $firstAlert;
-    }
-
-    /**
-     * @param String
-     */
-    public function setSecondAlert($secondAlert) {
-        $this->secondAlert = $secondAlert;
-    }
-
-    /**
-     * @param String
-     */
-    public function setThirdAlert($thirdAlert) {
-        $this->thirdAlert = $thirdAlert;
-    }
-
-    /**
-     * @param String
-     */
-    public function setFourthAlert($fourthAlert) {
-        $this->fourthAlert = $fourthAlert;
-    }
-
-    /**
-     * @param String
-     */
-    public function setLogoUrl($logoUrl) {
+    public function setLogoUrl($logoUrl)
+    {
         $this->logoUrl = $logoUrl;
+
+        return $this;
+    }
+
+    /**
+     * Gets the logo url
+     *
+     * @return string
+     */
+    public function getLogoUrl()
+    {
+        return $this->logoUrl;
     }
 }

--- a/RedePay/Tracking/Request/TrackingCreate.php
+++ b/RedePay/Tracking/Request/TrackingCreate.php
@@ -2,6 +2,7 @@
 
 namespace RedePay\Tracking\Request;
 
+use RedePay\Tracking\Tracking;
 use \RedePay\Utils\RequestInterface;
 
 /**
@@ -10,41 +11,88 @@ use \RedePay\Utils\RequestInterface;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class TrackingCreate implements RequestInterface {
-	private $tracking;
-	private $transactionId;
+class TrackingCreate implements RequestInterface
+{
+    /**
+     * The Tracking object
+     *
+     * @var Tracking
+     */
+    private $tracking;
 
-	public function __construct($tracking, $transactionId) {
+    /**
+     * The transaction ID
+     *
+     * @var string
+     */
+    private $transactionId;
+
+    /**
+     * TrackingCreate constructor.
+     *
+     * @param Tracking $tracking
+     * @param string $transactionId
+     */
+    public function __construct(Tracking $tracking, $transactionId)
+    {
         $this->tracking = $tracking;
         $this->transactionId = $transactionId;
     }
 
-	public function getPayload() {
-		$trackingNumber = $this->tracking->getCode();
-		
-		$parameters = array(
-			"trackingNumber" => $trackingNumber
-		);
-		return json_encode($parameters, JSON_UNESCAPED_UNICODE);
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getPayload()
+    {
+        $trackingNumber = $this->tracking->getCode();
+        
+        $parameters = array(
+            "trackingNumber" => $trackingNumber
+        );
+        return json_encode($parameters, JSON_UNESCAPED_UNICODE);
+    }
 
-    public function getTransactionId() {
+    /**
+     * Gets the transaction ID
+     *
+     * @return string
+     */
+    public function getTransactionId()
+    {
         return $this->transactionId;
     }
 
-	public function getPath() {
-		return sprintf("%s/transactions/%s/trackings", $this->getApiUrl(), $this->getTransactionId());
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return sprintf("%s/transactions/%s/trackings", $this->getApiUrl(), $this->getTransactionId());
+    }
 
-	public function getData() {
-		return null;
-	}
+    /**
+     * Gets the data
+     *
+     * @return null
+     */
+    public function getData()
+    {
+        return null;
+    }
 
-	public function getMethod() {
-		return self::HTTP_POST;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethod()
+    {
+        return self::HTTP_POST;
+    }
 
-	public function getApiUrl() {
-		return self::API_URL;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiUrl()
+    {
+        return self::API_URL;
+    }
 }

--- a/RedePay/Tracking/Request/TrackingCreate.php
+++ b/RedePay/Tracking/Request/TrackingCreate.php
@@ -1,8 +1,15 @@
 <?php
+
 namespace RedePay\Tracking\Request;
 
 use \RedePay\Utils\RequestInterface;
 
+/**
+ * Class TrackingCreate
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class TrackingCreate implements RequestInterface {
 	private $tracking;
 	private $transactionId;

--- a/RedePay/Tracking/Request/TrackingCreate.php
+++ b/RedePay/Tracking/Request/TrackingCreate.php
@@ -3,7 +3,7 @@
 namespace RedePay\Tracking\Request;
 
 use RedePay\Tracking\Tracking;
-use \RedePay\Utils\RequestInterface;
+use RedePay\Utils\RequestInterface;
 
 /**
  * Class TrackingCreate

--- a/RedePay/Tracking/Request/TrackingDelete.php
+++ b/RedePay/Tracking/Request/TrackingDelete.php
@@ -2,6 +2,7 @@
 
 namespace RedePay\Tracking\Request;
 
+use RedePay\Tracking\Tracking;
 use \RedePay\Utils\RequestInterface;
 
 /**
@@ -10,41 +11,88 @@ use \RedePay\Utils\RequestInterface;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class TrackingDelete implements RequestInterface {
-	private $tracking;
-	private $transactionId;
+class TrackingDelete implements RequestInterface
+{
+    /**
+     * The Tracking object
+     *
+     * @var Tracking
+     */
+    private $tracking;
 
-	public function __construct($tracking, $transactionId) {
+    /**
+     * The transaction ID
+     *
+     * @var string
+     */
+    private $transactionId;
+
+    /**
+     * TrackingDelete constructor.
+     *
+     * @param Tracking $tracking
+     * @param string $transactionId
+     */
+    public function __construct(Tracking $tracking, $transactionId)
+    {
         $this->tracking = $tracking;
         $this->transactionId = $transactionId;
     }
 
-	public function getPayload() {
-		$reason = $this->tracking->getReason();
-		
-		$parameters = array(
-			"reason" => $reason
-		);
-		return json_encode($parameters, JSON_UNESCAPED_UNICODE);
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getPayload()
+    {
+        $reason = $this->tracking->getReason();
+        
+        $parameters = array(
+            "reason" => $reason
+        );
+        return json_encode($parameters, JSON_UNESCAPED_UNICODE);
+    }
 
-    public function getTransactionId() {
+    /**
+     * Gets the transaction ID
+     *
+     * @return string
+     */
+    public function getTransactionId()
+    {
         return $this->transactionId;
     }
 
-	public function getPath() {
-		return sprintf("%s/transactions/%s/trackings", $this->getApiUrl(), $this->getTransactionId());
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return sprintf("%s/transactions/%s/trackings", $this->getApiUrl(), $this->getTransactionId());
+    }
 
-	public function getData() {
-		return null;
-	}
+    /**
+     * Gets the data
+     *
+     * @return null
+     */
+    public function getData()
+    {
+        return null;
+    }
 
-	public function getMethod() {
-		return self::HTTP_DELETE;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethod()
+    {
+        return self::HTTP_DELETE;
+    }
 
-	public function getApiUrl() {
-		return self::API_URL;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiUrl()
+    {
+        return self::API_URL;
+    }
 }

--- a/RedePay/Tracking/Request/TrackingDelete.php
+++ b/RedePay/Tracking/Request/TrackingDelete.php
@@ -3,7 +3,7 @@
 namespace RedePay\Tracking\Request;
 
 use RedePay\Tracking\Tracking;
-use \RedePay\Utils\RequestInterface;
+use RedePay\Utils\RequestInterface;
 
 /**
  * Class TrackingDelete

--- a/RedePay/Tracking/Request/TrackingDelete.php
+++ b/RedePay/Tracking/Request/TrackingDelete.php
@@ -1,8 +1,15 @@
 <?php
+
 namespace RedePay\Tracking\Request;
 
 use \RedePay\Utils\RequestInterface;
 
+/**
+ * Class TrackingDelete
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class TrackingDelete implements RequestInterface {
 	private $tracking;
 	private $transactionId;

--- a/RedePay/Tracking/Tracking.php
+++ b/RedePay/Tracking/Tracking.php
@@ -8,53 +8,82 @@ namespace RedePay\Tracking;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Tracking {
+class Tracking
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * The tracking number
+     *
+     * @var string
      */
     private $trackingNumber;
 
     /**
-     * @param String
+     * The tracking change reason
+     *
+     * @var string
      */
     private $reason;
 
     /**
-     * @param Tracking
+     * Tracking constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Tracking object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Sets the tracking number/code
+     *
+     * @param string $trackingNumber
+     * @return Tracking
      */
-    public function getCode() {
+    public function setCode($trackingNumber)
+    {
+        $this->trackingNumber = $trackingNumber;
+
+        return $this;
+    }
+
+    /**
+     * Gets the tracking number
+     *
+     * @return string
+     */
+    public function getCode()
+    {
         return $this->trackingNumber;
     }
 
     /**
-     * @return String
+     * Sets the tracking number update reason
+     *
+     * @param string $reason
+     * @return Tracking
      */
-    public function getReason() {
-        return $this->reason;
-    }
-
-    /**
-     * @param String
-     */
-    public function setCode($trackingNumber) {
-        $this->trackingNumber = $trackingNumber;
-    }
-
-    /**
-     * @param String
-     */
-    public function setReason($reason) {
+    public function setReason($reason)
+    {
         $this->reason = $reason;
+
+        return $this;
+    }
+
+    /**
+     * Gets the tracking number update reason
+     *
+     * @return string
+     */
+    public function getReason()
+    {
+        return $this->reason;
     }
 }

--- a/RedePay/Tracking/Tracking.php
+++ b/RedePay/Tracking/Tracking.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Tracking;
 
+/**
+ * Class Tracking
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Tracking {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Tracking/Tracking.php
+++ b/RedePay/Tracking/Tracking.php
@@ -2,6 +2,8 @@
 
 namespace RedePay\Tracking;
 
+use RedePay\Utils\Fillable;
+
 /**
  * Class Tracking
  *
@@ -13,7 +15,7 @@ class Tracking
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * The tracking number

--- a/RedePay/Tracking/TrackingBuilder.php
+++ b/RedePay/Tracking/TrackingBuilder.php
@@ -10,8 +10,16 @@ use \RedePay\Tracking\Tracking;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-trait TrackingBuilder {
-    private function buildTracking($data) {
+trait TrackingBuilder
+{
+    /**
+     * Factory a Tracking object
+     *
+     * @param \stdClass $data
+     * @return \RedePay\Tracking\Tracking
+     */
+    private function buildTracking($data)
+    {
         return new Tracking(get_object_vars($data));
     }
 }

--- a/RedePay/Tracking/TrackingBuilder.php
+++ b/RedePay/Tracking/TrackingBuilder.php
@@ -1,13 +1,15 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Tracking;
 
 use \RedePay\Tracking\Tracking;
 
+/**
+ * Class TrackingBuilder
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 trait TrackingBuilder {
     private function buildTracking($data) {
         return new Tracking(get_object_vars($data));

--- a/RedePay/Tracking/TrackingHandler.php
+++ b/RedePay/Tracking/TrackingHandler.php
@@ -1,8 +1,4 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Tracking;
 
@@ -11,6 +7,12 @@ use \RedePay\Utils\AbstractHandler;
 use \RedePay\Tracking\Request\TrackingCreate;
 use \RedePay\Tracking\Request\TrackingDelete;
 
+/**
+ * Class TrackingHandler
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class TrackingHandler extends AbstractHandler {
     use TrackingBuilder;
 

--- a/RedePay/Tracking/TrackingHandler.php
+++ b/RedePay/Tracking/TrackingHandler.php
@@ -13,16 +13,36 @@ use \RedePay\Tracking\Request\TrackingDelete;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class TrackingHandler extends AbstractHandler {
+class TrackingHandler extends AbstractHandler
+{
+    /**
+     * Traits
+     */
     use TrackingBuilder;
 
-    public function create($tracking, $transactionId) {
+    /**
+     * Creates a new tracking resource
+     *
+     * @param Tracking $tracking
+     * @param string $transactionId
+     * @return Tracking
+     */
+    public function create(Tracking $tracking, $transactionId)
+    {
         $request = new TrackingCreate($tracking, $transactionId);
         $response = $this->client->send($request);
         return $this->buildTracking($response);
     }
 
-    public function delete($tracking, $transactionId) {
+    /**
+     * Delete an existing tracking resource
+     *
+     * @param Tracking $tracking
+     * @param string $transactionId
+     * @return Tracking
+     */
+    public function delete(Tracking $tracking, $transactionId)
+    {
         $request = new TrackingDelete($tracking, $transactionId);
         $response = $this->client->send($request);
         return $this->buildTracking($response);

--- a/RedePay/Tracking/TrackingHandler.php
+++ b/RedePay/Tracking/TrackingHandler.php
@@ -2,10 +2,9 @@
 
 namespace RedePay\Tracking;
 
-use \RedePay\Utils\Client;
-use \RedePay\Utils\AbstractHandler;
-use \RedePay\Tracking\Request\TrackingCreate;
-use \RedePay\Tracking\Request\TrackingDelete;
+use RedePay\Utils\AbstractHandler;
+use RedePay\Tracking\Request\TrackingCreate;
+use RedePay\Tracking\Request\TrackingDelete;
 
 /**
  * Class TrackingHandler

--- a/RedePay/Transaction/Request/TransactionGet.php
+++ b/RedePay/Transaction/Request/TransactionGet.php
@@ -2,7 +2,7 @@
 
 namespace RedePay\Transaction\Request;
 
-use \RedePay\Utils\RequestInterface;
+use RedePay\Utils\RequestInterface;
 
 /**
  * Class TransactionGet

--- a/RedePay/Transaction/Request/TransactionGet.php
+++ b/RedePay/Transaction/Request/TransactionGet.php
@@ -1,13 +1,15 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Transaction\Request;
 
 use \RedePay\Utils\RequestInterface;
 
+/**
+ * Class TransactionGet
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class TransactionGet implements RequestInterface {
     private $transactionId;
 

--- a/RedePay/Transaction/Request/TransactionGet.php
+++ b/RedePay/Transaction/Request/TransactionGet.php
@@ -10,30 +10,64 @@ use \RedePay\Utils\RequestInterface;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class TransactionGet implements RequestInterface {
+class TransactionGet implements RequestInterface
+{
+    /**
+     * The transaction ID
+     *
+     * @var string
+     */
     private $transactionId;
 
-    public function __construct($transactionId) {
+    /**
+     * TransactionGet constructor.
+     *
+     * @param string $transactionId
+     */
+    public function __construct($transactionId)
+    {
         $this->transactionId = $transactionId;
     }
 
-    public function getTransactionId() {
+    /**
+     * Gets the transaction ID
+     *
+     * @return string
+     */
+    public function getTransactionId()
+    {
         return $this->transactionId;
     }
 
-    public function getPath() {
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
         return sprintf("%s/transactions/%s", $this->getApiUrl(), $this->getTransactionId());
     }
 
-    public function getPayload() {
+    /**
+     * {@inheritdoc}
+     */
+    public function getPayload()
+    {
         return [];
     }
 
-    public function getMethod() {
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethod()
+    {
         return self::HTTP_GET;
     }
 
-    public function getApiUrl() {
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiUrl()
+    {
         return self::API_URL;
     }
 }

--- a/RedePay/Transaction/Transaction.php
+++ b/RedePay/Transaction/Transaction.php
@@ -2,11 +2,12 @@
 
 namespace RedePay\Transaction;
 
+use RedePay\Customer\Customer;
 use RedePay\History\History;
 use RedePay\Item\Item;
-use \RedePay\Payment\Payment;
-use \RedePay\Customer\Customer;
+use RedePay\Payment\Payment;
 use RedePay\Shipping\Shipping;
+use RedePay\Utils\Fillable;
 
 /**
  * Class Transaction
@@ -19,7 +20,7 @@ class Transaction
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * The transaction ID

--- a/RedePay/Transaction/Transaction.php
+++ b/RedePay/Transaction/Transaction.php
@@ -1,14 +1,16 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Transaction;
 
 use \RedePay\Payment\Payment;
 use \RedePay\Customer\Customer;
 
+/**
+ * Class Transaction
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Transaction {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Transaction/Transaction.php
+++ b/RedePay/Transaction/Transaction.php
@@ -2,8 +2,11 @@
 
 namespace RedePay\Transaction;
 
+use RedePay\History\History;
+use RedePay\Item\Item;
 use \RedePay\Payment\Payment;
 use \RedePay\Customer\Customer;
+use RedePay\Shipping\Shipping;
 
 /**
  * Class Transaction
@@ -11,172 +14,243 @@ use \RedePay\Customer\Customer;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Transaction {
+class Transaction
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * The transaction ID
+     *
+     * @var string
      */
     private $id;
 
     /**
-     * @param String
+     * The transaction reference
+     *
+     * @var string
      */
     private $reference;
 
     /**
-     * @param String
+     * The transaction status
+     *
+     * @var string
      */
     private $status;
 
     /**
-     * @param String
+     * The transaction amount
+     *
+     * @var float
      */
     private $amount;
 
     /**
-     * @param String
+     * The transaction discount amount
+     *
+     * @var float
      */
     private $discount;
 
     /**
-     * @param String
+     * The transaction creation date
+     *
+     * @var string
      */
     private $creationDate;
 
     /**
-     * @param Customer
+     * The Customer object
+     *
+     * @var Customer
      */
     private $customer;
 
     /**
-     * @param Payment
+     * The Payment object
+     *
+     * @var Payment
      */
     private $payment;
 
     /**
-     * @param Shipping
+     * The Shipping object
+     *
+     * @var Shipping
      */
     private $shipping;
 
     /**
-     * @param Item[]
+     * The items array
+     *
+     * @var Item[]
      */
     private $items;
 
     /**
-     * @param History[]
+     * The transaction status history
+     *
+     * @var History[]
      */
     private $statusHistory;
 
     /**
-     * @param String
+     * The payment method
+     *
+     * @var string
      */
     private $paymentMethod;
 
     /**
-     * @param String
+     * The card brand
+     *
+     * @var string
      */
     private $cardBrand;
 
     /**
-     * @param String
+     * The installments number
+     *
+     * @var int
      */
     private $installments;
 
     /**
-     * @param String
+     * The customer name
+     *
+     * @var string
      */
     private $customerName;
 
     /**
-     * @param String
+     * The customer email
+     * @var string
      */
     private $customerEmail;
 
     /**
-     * @param Transaction
+     * Transaction constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Transaction object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Gets the transaction ID
+     *
+     * @return string
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
     /**
-     * @return String
+     * Gets the transaction reference
+     *
+     * @return string
      */
-    public function getReference() {
+    public function getReference()
+    {
         return $this->reference;
     }
 
     /**
-     * @return String
+     * Gets the transaction status
+     *
+     * @return string
      */
-    public function getStatus() {
+    public function getStatus()
+    {
         return $this->status;
     }
 
     /**
-     * @return String
+     * Gets the transaction total amount
+     *
+     * @return float
      */
-    public function getAmount() {
+    public function getAmount()
+    {
         return $this->amount;
     }
 
     /**
-     * @return String
+     * Gets the transaction discount amount
+     *
+     * @return float
      */
-    public function getDiscount() {
+    public function getDiscount()
+    {
         return $this->discount;
     }
 
     /**
-     * @return String
+     * Gets the transaction creation date
+     *
+     * @return string
      */
-    public function getCreationDate() {
+    public function getCreationDate()
+    {
         return $this->creationDate;
     }
 
     /**
+     * Gets the Customer
+     *
      * @return Customer
      */
-    public function getCustomer() {
+    public function getCustomer()
+    {
         return $this->customer;
     }
 
     /**
+     * Gets the Payment
+     *
      * @return Payment
      */
-    public function getPayment() {
+    public function getPayment()
+    {
         return new $this->payment;
     }
 
     /**
+     * Gets the Shipping
+     *
      * @return Shipping
      */
-    public function getShipping() {
+    public function getShipping()
+    {
         return $this->shipping;
     }
 
     /**
+     * Gets the items array
+     *
      * @return Item[]
      */
-    public function getItems() {
+    public function getItems()
+    {
         return $this->items;
     }
 
     /**
-     * @return History
+     * Gets the transaction status history
+     *
+     * @return History[]
      */
-    public function getStatusHistory() {
+    public function getStatusHistory()
+    {
         return $this->statusHistory;
     }
 }

--- a/RedePay/Transaction/TransactionBuilder.php
+++ b/RedePay/Transaction/TransactionBuilder.php
@@ -15,22 +15,35 @@ use \RedePay\Transaction\Transaction;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-trait TransactionBuilder {
+trait TransactionBuilder
+{
+    /**
+     * Traits
+     */
     use \RedePay\Shipping\ShippingBuilder;
-    
-    private function buildTransaction($data) {
-        $data->customer = new Customer((object) array(
-                "name" => $data->customerName,
-                "email" => $data->customerEmail
-            )
-        );
 
-        $data->payment = new Payment((object) array(
-                "method" => $data->paymentMethod,
-                "cardBrand" => $data->cardBrand,
-                "installments" => $data->installments
-            )
-        );
+    /**
+     * Factory a Transaction object
+     *
+     * @param \stdClass $data
+     * @return \RedePay\Transaction\Transaction
+     */
+    private function buildTransaction($data)
+    {
+        $customer = [
+            'name' => $data->customerName,
+            'email' => $data->customerEmail
+        ];
+
+        $data->customer = new Customer((object)$customer);
+
+        $payment = [
+            'method' => $data->paymentMethod,
+            'cardBrand' => $data->cardBrand,
+            'installments' => $data->installments
+        ];
+
+        $data->payment = new Payment((object)$payment);
 
         $data->shipping->trackingNumber = $data->trackingNumber;
         $data->shipping = new Shipping($this->buildShipping($data->shipping));

--- a/RedePay/Transaction/TransactionBuilder.php
+++ b/RedePay/Transaction/TransactionBuilder.php
@@ -1,8 +1,4 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Transaction;
 
@@ -13,6 +9,12 @@ use \RedePay\Item\Item;
 use \RedePay\History\History;
 use \RedePay\Transaction\Transaction;
 
+/**
+ * Class TransactionBuilder
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 trait TransactionBuilder {
     use \RedePay\Shipping\ShippingBuilder;
     

--- a/RedePay/Transaction/TransactionBuilder.php
+++ b/RedePay/Transaction/TransactionBuilder.php
@@ -2,12 +2,12 @@
 
 namespace RedePay\Transaction;
 
-use \RedePay\Customer\Customer;
-use \RedePay\Payment\Payment;
-use \RedePay\Shipping\Shipping;
-use \RedePay\Item\Item;
-use \RedePay\History\History;
-use \RedePay\Transaction\Transaction;
+use RedePay\Customer\Customer;
+use RedePay\History\History;
+use RedePay\Item\Item;
+use RedePay\Payment\Payment;
+use RedePay\Shipping\Shipping;
+use RedePay\Shipping\ShippingBuilder;
 
 /**
  * Class TransactionBuilder
@@ -20,13 +20,13 @@ trait TransactionBuilder
     /**
      * Traits
      */
-    use \RedePay\Shipping\ShippingBuilder;
+    use ShippingBuilder;
 
     /**
      * Factory a Transaction object
      *
      * @param \stdClass $data
-     * @return \RedePay\Transaction\Transaction
+     * @return Transaction
      */
     private function buildTransaction($data)
     {

--- a/RedePay/Transaction/TransactionHandler.php
+++ b/RedePay/Transaction/TransactionHandler.php
@@ -12,10 +12,21 @@ use \RedePay\Transaction\Request\TransactionGet;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class TransactionHandler extends AbstractHandler {
+class TransactionHandler extends AbstractHandler
+{
+    /**
+     * Traits
+     */
     use \RedePay\Transaction\TransactionBuilder;
 
-    public function get($transactionId) {
+    /**
+     * Gets a transaction
+     *
+     * @param string $transactionId
+     * @return Transaction
+     */
+    public function get($transactionId)
+    {
         $request = new TransactionGet($transactionId);
         $response = $this->client->send($request);
         return $this->buildTransaction($response);

--- a/RedePay/Transaction/TransactionHandler.php
+++ b/RedePay/Transaction/TransactionHandler.php
@@ -2,9 +2,8 @@
 
 namespace RedePay\Transaction;
 
-use \RedePay\Utils\AbstractHandler;
-use \RedePay\Utils\Client;
-use \RedePay\Transaction\Request\TransactionGet;
+use RedePay\Transaction\Request\TransactionGet;
+use RedePay\Utils\AbstractHandler;
 
 /**
  * Class TransactionHandler
@@ -17,7 +16,7 @@ class TransactionHandler extends AbstractHandler
     /**
      * Traits
      */
-    use \RedePay\Transaction\TransactionBuilder;
+    use TransactionBuilder;
 
     /**
      * Gets a transaction

--- a/RedePay/Transaction/TransactionHandler.php
+++ b/RedePay/Transaction/TransactionHandler.php
@@ -1,8 +1,4 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Transaction;
 
@@ -10,6 +6,12 @@ use \RedePay\Utils\AbstractHandler;
 use \RedePay\Utils\Client;
 use \RedePay\Transaction\Request\TransactionGet;
 
+/**
+ * Class TransactionHandler
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class TransactionHandler extends AbstractHandler {
     use \RedePay\Transaction\TransactionBuilder;
 

--- a/RedePay/Url/Url.php
+++ b/RedePay/Url/Url.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Url;
 
+/**
+ * Class Url
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Url {
     use \RedePay\Utils\Fillable;
 

--- a/RedePay/Url/Url.php
+++ b/RedePay/Url/Url.php
@@ -2,6 +2,8 @@
 
 namespace RedePay\Url;
 
+use RedePay\Utils\Fillable;
+
 /**
  * Class Url
  *
@@ -13,7 +15,7 @@ class Url
     /**
      * Traits
      */
-    use \RedePay\Utils\Fillable;
+    use Fillable;
 
     /**
      * Enum constants

--- a/RedePay/Url/Url.php
+++ b/RedePay/Url/Url.php
@@ -8,53 +8,90 @@ namespace RedePay\Url;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Url {
+class Url
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\Fillable;
 
     /**
-     * @param String
+     * Enum constants
+     */
+    const TYPE_CANCEL             = 'cancel';
+    const TYPE_NOTIFICATION       = 'notification';
+    const TYPE_ORDER_NOTIFICATION = 'orderNotification';
+    const TYPE_REDIRECT           = 'redirect';
+
+    /**
+     * The URL type
+     *
+     * @var string
      */
     private $kind;
 
     /**
-     * @param String
+     * The URL
+     *
+     * @var string
      */
     private $url;
 
     /**
-     * @param Url
+     * Url constructor.
+     *
+     * @param array|null $data The default data to be filled in the current Url object
      */
-    public function __construct($data = null) {
-        if(isset($data)) {
+    public function __construct(array $data = null)
+    {
+        if (isset($data)) {
             $this->fill($data);
         }
     }
 
     /**
-     * @return String
+     * Sets the type
+     *
+     * @param string $kind
+     * @return Url
      */
-    public function getKind() {
+    public function setKind($kind)
+    {
+        $this->kind = $kind;
+
+        return $this;
+    }
+
+    /**
+     * Gets the type
+     *
+     * @return string
+     */
+    public function getKind()
+    {
         return $this->kind;
     }
 
     /**
-     * @return String
+     * Sets the url
+     *
+     * @param string $url
+     * @return Url
      */
-    public function getUrl() {
-        return $this->url;
-    }
-
-    /**
-     * @param String
-     */
-    public function setKind($kind) {
-        $this->kind = $kind;
-    }
-
-    /**
-     * @param String
-     */
-    public function setUrl($url) {
+    public function setUrl($url)
+    {
         $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * Gets the url
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
     }
 }

--- a/RedePay/Utils/AbstractHandler.php
+++ b/RedePay/Utils/AbstractHandler.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Utils;
 
+/**
+ * Class AbstractHandler
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 abstract class AbstractHandler {
     /**
      * @param Client

--- a/RedePay/Utils/AbstractHandler.php
+++ b/RedePay/Utils/AbstractHandler.php
@@ -8,16 +8,22 @@ namespace RedePay\Utils;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-abstract class AbstractHandler {
+abstract class AbstractHandler
+{
     /**
-     * @param Client
+     * The HTTP Client
+     *
+     * @var Client
      */
     protected $client;
 
     /**
-     * @param Client
+     * AbstractHandler constructor.
+     *
+     * @param Client $client
      */
-    public function __construct($client) {
+    public function __construct($client)
+    {
         $this->client = $client;
     }
 }

--- a/RedePay/Utils/AutoLoader.php
+++ b/RedePay/Utils/AutoLoader.php
@@ -23,7 +23,8 @@ $mapping = array(
     "RedePay\Settings\Settings" => $directory . "/Settings/Settings.php",
     "RedePay\Shipping\Shipping" => $directory . "/Shipping/Shipping.php",
     "RedePay\Shipping\ShippingBuilder" => $directory . "/Shipping/ShippingBuilder.php",
-    "RedePay\ShoppingCartRecovery\ShoppingCartRecovery" => $directory . "/ShoppingCartRecovery/ShoppingCartRecovery.php",
+    "RedePay\ShoppingCartRecovery\ShoppingCartRecovery" =>
+        $directory . "/ShoppingCartRecovery/ShoppingCartRecovery.php",
     "RedePay\Tracking\Tracking" => $directory . "/Tracking/Tracking.php",
     "RedePay\Tracking\TrackingHandler" => $directory . "/Tracking/TrackingHandler.php",
     "RedePay\Tracking\TrackingBuilder" => $directory . "/Tracking/TrackingBuilder.php",

--- a/RedePay/Utils/AutoLoader.php
+++ b/RedePay/Utils/AutoLoader.php
@@ -1,8 +1,8 @@
 <?php
 /**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 
 $directory = substr(__DIR__, 0, -6);
 

--- a/RedePay/Utils/CaseConverter.php
+++ b/RedePay/Utils/CaseConverter.php
@@ -8,14 +8,29 @@ namespace RedePay\Utils;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-trait CaseConverter {
-    public function toUpperCase($sentence) {
+trait CaseConverter
+{
+    /**
+     * Converts a string to uppercase
+     *
+     * @param string $sentence
+     * @return string
+     */
+    public function toUpperCase($sentence)
+    {
         return preg_replace_callback("/(?:^|_)([a-zA-Z])/", function ($word) {
             return strtoupper($word[1]);
         }, $sentence);
     }
 
-    public function toLowerCase($sentence) {
+    /**
+     * Converts a string to lowercase
+     *
+     * @param string $sentence
+     * @return string
+     */
+    public function toLowerCase($sentence)
+    {
         return lcfirst($this->toUpperCase($sentence));
     }
 }

--- a/RedePay/Utils/CaseConverter.php
+++ b/RedePay/Utils/CaseConverter.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Utils;
 
+/**
+ * Class CaseConverter
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 trait CaseConverter {
     public function toUpperCase($sentence) {
         return preg_replace_callback("/(?:^|_)([a-zA-Z])/", function ($word) {

--- a/RedePay/Utils/Client.php
+++ b/RedePay/Utils/Client.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Utils;
 
+/**
+ * Class Client
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 class Client {
 	private $apiKey;
 

--- a/RedePay/Utils/Client.php
+++ b/RedePay/Utils/Client.php
@@ -8,58 +8,91 @@ namespace RedePay\Utils;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-class Client {
-	private $apiKey;
+class Client
+{
+    /**
+     * The API key
+     *
+     * @var string
+     */
+    private $apiKey;
 
-	public function __construct($apiKey) {
-		$this->apiKey = $apiKey;
-	}
+    /**
+     * Client constructor.
+     *
+     * @param string $apiKey
+     */
+    public function __construct($apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
 
-	public function send(RequestInterface $request) {
-		$response = $this->execute($request->getPath(), $request->getMethod(), $request->getPayLoad());
-		return json_decode($response);
-	}
+    /**
+     * Sends a request
+     *
+     * @param RequestInterface $request
+     * @return \stdClass
+     */
+    public function send(RequestInterface $request)
+    {
+        $response = $this->execute($request->getPath(), $request->getMethod(), $request->getPayLoad());
+        return json_decode($response);
+    }
 
-	private function execute($url, $method, $data) {
-		$headers = array(
-			"access-token: " . $this->getApiKey(),
-			"Accept: application/json",
-			"Content-Type: application/json"
-		);
+    /**
+     * Execute a HTTP request
+     *
+     * @param string $url
+     * @param string $method
+     * @param string $data
+     * @return string
+     */
+    private function execute($url, $method, $data)
+    {
+        $headers = array(
+            "access-token: " . $this->getApiKey(),
+            "Accept: application/json",
+            "Content-Type: application/json"
+        );
 
-		$curl = curl_init();
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
-		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
 
-		if($method == "POST") {
-			curl_setopt($curl, CURLOPT_POST, true);
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
-		}
-		elseif($method == "DELETE") {
-			curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
-		}
+        if ($method == "POST") {
+            curl_setopt($curl, CURLOPT_POST, true);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
+        } elseif ($method == "DELETE") {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
+        }
 
-		curl_setopt($curl, CURLOPT_URL, $url);
-		curl_setopt($curl, CURLOPT_USERAGENT, "Rede-Pay/1.0 (+https://github.com/marjoel/redepay-sdk-php)");
-		curl_setopt($curl, CURLOPT_VERBOSE, 0);
-		curl_setopt($curl, CURLOPT_HEADER, 1);
+        curl_setopt($curl, CURLOPT_URL, $url);
+        curl_setopt($curl, CURLOPT_USERAGENT, "Rede-Pay/1.0 (+https://github.com/marjoel/redepay-sdk-php)");
+        curl_setopt($curl, CURLOPT_VERBOSE, 0);
+        curl_setopt($curl, CURLOPT_HEADER, 1);
 
-		$response = curl_exec($curl);
-		$http_header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
-		$http_body = substr($response, $http_header_size);
+        $response = curl_exec($curl);
+        $http_header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
+        $http_body = substr($response, $http_header_size);
 
-		$data = $http_body;
+        $data = $http_body;
 
-		if(json_last_error() > 0) { 
-			$data = $http_body;
-		}
-		return $data;
-	}
-	
-	public function getApiKey() {
-		return $this->apiKey;
-	}
+        if (json_last_error() > 0) {
+            $data = $http_body;
+        }
+        return $data;
+    }
+
+    /**
+     * Gets the API key
+     *
+     * @return string
+     */
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
 }

--- a/RedePay/Utils/DateFormatter.php
+++ b/RedePay/Utils/DateFormatter.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Utils;
 
+/**
+ * Class DateFormatter
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 trait DateFormatter {
     public function getDateInMicroseconds(\DateTime $date) {
         return substr($date->format('Uu'), 0, 13);

--- a/RedePay/Utils/DateFormatter.php
+++ b/RedePay/Utils/DateFormatter.php
@@ -8,8 +8,16 @@ namespace RedePay\Utils;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-trait DateFormatter {
-    public function getDateInMicroseconds(\DateTime $date) {
+trait DateFormatter
+{
+    /**
+     * Gets a date in microseconds format
+     *
+     * @param \DateTime $date
+     * @return string
+     */
+    public function getDateInMicroseconds(\DateTime $date)
+    {
         return substr($date->format('Uu'), 0, 13);
     }
 }

--- a/RedePay/Utils/Fillable.php
+++ b/RedePay/Utils/Fillable.php
@@ -8,14 +8,24 @@ namespace RedePay\Utils;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-trait Fillable {
+trait Fillable
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\CaseConverter;
 
-    private function fill($data) {
-        foreach($data as $key => $value) {
+    /**
+     * Fill the current object with a data array
+     *
+     * @param array|\stdClass $data
+     */
+    private function fill($data)
+    {
+        foreach ($data as $key => $value) {
             $field = $this->toLowerCase($key);
 
-            if(property_exists($this, $field)) {
+            if (property_exists($this, $field)) {
                 $this->$field = $value;
             }
         }

--- a/RedePay/Utils/Fillable.php
+++ b/RedePay/Utils/Fillable.php
@@ -13,7 +13,7 @@ trait Fillable
     /**
      * Traits
      */
-    use \RedePay\Utils\CaseConverter;
+    use CaseConverter;
 
     /**
      * Fill the current object with a data array

--- a/RedePay/Utils/Fillable.php
+++ b/RedePay/Utils/Fillable.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Utils;
 
+/**
+ * Class Fillable
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 trait Fillable {
     use \RedePay\Utils\CaseConverter;
 

--- a/RedePay/Utils/RemoveMask.php
+++ b/RedePay/Utils/RemoveMask.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Daniel Pavone [danielpavone@gmail.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Utils;
 
+/**
+ * Class RemoveMask
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 trait RemoveMask {
     
     /**

--- a/RedePay/Utils/RemoveMask.php
+++ b/RedePay/Utils/RemoveMask.php
@@ -8,12 +8,16 @@ namespace RedePay\Utils;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-trait RemoveMask {
-    
+trait RemoveMask
+{
     /**
-     * @param String
+     * Removes masks and format characters
+     *
+     * @param string $value
+     * @return string
      */
-    private function removeMask($value) {
+    private function removeMask($value)
+    {
         return preg_replace("/[^0-9]/", "", $value);
     }
 }

--- a/RedePay/Utils/RequestInterface.php
+++ b/RedePay/Utils/RequestInterface.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Utils;
 
+/**
+ * Interface RequestInterface
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 interface RequestInterface {
     const HTTP_GET = "GET";
     const HTTP_POST = "POST";

--- a/RedePay/Utils/RequestInterface.php
+++ b/RedePay/Utils/RequestInterface.php
@@ -8,18 +8,46 @@ namespace RedePay\Utils;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-interface RequestInterface {
+interface RequestInterface
+{
+    /**
+     * Available HTTP methods
+     */
     const HTTP_GET = "GET";
     const HTTP_POST = "POST";
     const HTTP_PUT = "PUT";
     const HTTP_DELETE = "DELETE";
+
+    /**
+     * The API URI
+     */
     const API_URL = "https://api.useredepay.com.br";
 
+    /**
+     * Gets the request payload
+     *
+     * @return string
+     */
     public function getPayload();
 
+    /**
+     * Gets the resource endpoint
+     *
+     * @return string
+     */
     public function getPath();
 
+    /**
+     * Gets the HTTP method
+     *
+     * @return string
+     */
     public function getMethod();
 
+    /**
+     * Gets the API URI
+     *
+     * @return string
+     */
     public function getApiUrl();
 }

--- a/RedePay/Utils/Validation/CpfValidator.php
+++ b/RedePay/Utils/Validation/CpfValidator.php
@@ -1,11 +1,13 @@
 <?php
-/**
-*  @author   Marjoel Moreira [marjoel@marjoel.com]
-*  @license  https://www.gnu.org/licenses/gpl-3.0.en.html
-*/
 
 namespace RedePay\Utils\Validation;
 
+/**
+ * Class CpfValidator
+ *
+ * @author Marjoel Moreira <marjoel@marjoel.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ */
 trait CpfValidator {
     use \RedePay\Utils\RemoveMask;
 

--- a/RedePay/Utils/Validation/CpfValidator.php
+++ b/RedePay/Utils/Validation/CpfValidator.php
@@ -8,10 +8,21 @@ namespace RedePay\Utils\Validation;
  * @author Marjoel Moreira <marjoel@marjoel.com>
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html
  */
-trait CpfValidator {
+trait CpfValidator
+{
+    /**
+     * Traits
+     */
     use \RedePay\Utils\RemoveMask;
 
-    public function cpfValidator($value) {
+    /**
+     * Validates a CPF string
+     *
+     * @param string $value
+     * @return bool
+     */
+    public function cpfValidator($value)
+    {
         $value = $this->removeMask($value);
         $regEx = "/^(0{11}|1{11}|2{11}|3{11}|4{11}|5{11}|6{11}|7{11}|8{11}|9{11})$/";
 
@@ -21,7 +32,15 @@ trait CpfValidator {
         return ($this->digitValidator($value, 9) && $this->digitValidator($value, 10));
     }
 
-    private function digitValidator($value, $digit) {
+    /**
+     * Validates the last two final digits
+     *
+     * @param string $value
+     * @param int $digit
+     * @return bool
+     */
+    private function digitValidator($value, $digit)
+    {
         $init = $digit - 9;
         $sum = 0;
 

--- a/RedePay/Utils/Validation/CpfValidator.php
+++ b/RedePay/Utils/Validation/CpfValidator.php
@@ -2,6 +2,8 @@
 
 namespace RedePay\Utils\Validation;
 
+use RedePay\Utils\RemoveMask;
+
 /**
  * Class CpfValidator
  *
@@ -13,7 +15,7 @@ trait CpfValidator
     /**
      * Traits
      */
-    use \RedePay\Utils\RemoveMask;
+    use RemoveMask;
 
     /**
      * Validates a CPF string

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
     "require": {
         "php": ">=5.5.9"
     },
-    "require-dev": {},
+    "require-dev": {
+        "squizlabs/php_codesniffer": "2.*",
+        "friendsofphp/php-cs-fixer": "^2.3@dev"
+    },
     "autoload": {
         "psr-4": { "RedePay\\": "RedePay/" }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,12 +4,1208 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "94ebe922f064c505c2b5ccdf558ee46c",
+    "content-hash": "1a0687a2c6b2ddc5ccc3571c4e63a3c0",
     "packages": [],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/annotations",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-02-24T16:22:25+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "0f6865696eda7c8d0b1f3d542171ff086b00994c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/0f6865696eda7c8d0b1f3d542171ff086b00994c",
+                "reference": "0f6865696eda7c8d0b1f3d542171ff086b00994c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.2",
+                "ext-tokenizer": "*",
+                "php": "^5.6 || >=7.0 <7.2",
+                "sebastian/diff": "^1.4",
+                "symfony/console": "^3.0",
+                "symfony/event-dispatcher": "^3.0",
+                "symfony/filesystem": "^3.0",
+                "symfony/finder": "^3.0",
+                "symfony/options-resolver": "^3.0",
+                "symfony/polyfill-php54": "^1.0",
+                "symfony/polyfill-php55": "^1.3",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-xml": "^1.3",
+                "symfony/process": "^3.0",
+                "symfony/stopwatch": "^3.0"
+            },
+            "conflict": {
+                "hhvm": "<3.18"
+            },
+            "require-dev": {
+                "gecko-packages/gecko-php-unit": "^2.0",
+                "justinrainbow/json-schema": "^5.0",
+                "phpunit/phpunit": "^4.5 || ^5.0",
+                "satooshi/php-coveralls": "^1.0",
+                "symfony/phpunit-bridge": "^3.2.2"
+            },
+            "suggest": {
+                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "ext-xml": "For better performance.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2017-04-21T17:09:10+00:00"
+        },
+        {
+            "name": "ircmaxell/password-compat",
+            "version": "1.0.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/password_compat.git",
+                "reference": "9b99377557a33a4129c9194e60a97a685fab21e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/password_compat/zipball/9b99377557a33a4129c9194e60a97a685fab21e0",
+                "reference": "9b99377557a33a4129c9194e60a97a685fab21e0",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/password.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@php.net",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash",
+            "homepage": "https://github.com/ircmaxell/password_compat",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "time": "2014-11-20T19:18:42+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2017-03-13T16:27:32+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "763d7adeb8c35d2af2b04c0f6cafeee059074dfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/763d7adeb8c35d2af2b04c0f6cafeee059074dfb",
+                "reference": "763d7adeb8c35d2af2b04c0f6cafeee059074dfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-03-07T07:26:53+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "f4e70f6196e5ab1c165ebc9fc32eaf37a5b46f17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f4e70f6196e5ab1c165ebc9fc32eaf37a5b46f17",
+                "reference": "f4e70f6196e5ab1c165ebc9fc32eaf37a5b46f17",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-04-20 05:40:05"
+        },
+        {
+            "name": "symfony/console",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "240ef75712a842899d5bdbb97bc83e02b362acbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/240ef75712a842899d5bdbb97bc83e02b362acbf",
+                "reference": "240ef75712a842899d5bdbb97bc83e02b362acbf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/debug": "~2.8|~3.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/dependency-injection": "~3.3",
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/filesystem": "~2.8|~3.0",
+                "symfony/http-kernel": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/filesystem": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-19T23:40:30+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "2a237220d7d24a4ac867f701fe07320f341b2454"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/2a237220d7d24a4ac867f701fe07320f341b2454",
+                "reference": "2a237220d7d24a4ac867f701fe07320f341b2454",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-20T17:12:40+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "73ccae57d5a439a9debf34e3f9bec78b56241949"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/73ccae57d5a439a9debf34e3f9bec78b56241949",
+                "reference": "73ccae57d5a439a9debf34e3f9bec78b56241949",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~3.3",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/stopwatch": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-13T13:45:25+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "57ecfd1448b71f76921590b14ed72a9e1bcc0ace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/57ecfd1448b71f76921590b14ed72a9e1bcc0ace",
+                "reference": "57ecfd1448b71f76921590b14ed72a9e1bcc0ace",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-12T14:14:56+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "ce309911aabd89ef885673ddb924076c1c410356"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ce309911aabd89ef885673ddb924076c1c410356",
+                "reference": "ce309911aabd89ef885673ddb924076c1c410356",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-12T14:14:56+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "ff48982d295bcac1fd861f934f041ebc73ae40f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ff48982d295bcac1fd861f934f041ebc73ae40f0",
+                "reference": "ff48982d295bcac1fd861f934f041ebc73ae40f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2017-04-12T14:14:56+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-11-14T01:06:16+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php54",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php54.git",
+                "reference": "90e085822963fdcc9d1c5b73deb3d2e5783b16a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php54/zipball/90e085822963fdcc9d1c5b73deb3d2e5783b16a0",
+                "reference": "90e085822963fdcc9d1c5b73deb3d2e5783b16a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php54\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-11-14T01:06:16+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php55",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php55.git",
+                "reference": "03e3f0350bca2220e3623a0e340eef194405fc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php55/zipball/03e3f0350bca2220e3623a0e340eef194405fc67",
+                "reference": "03e3f0350bca2220e3623a0e340eef194405fc67",
+                "shasum": ""
+            },
+            "require": {
+                "ircmaxell/password-compat": "~1.0",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php55\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.5+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-11-14T01:06:16+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "13ce343935f0f91ca89605a2f6ca6f5c2f3faac2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/13ce343935f0f91ca89605a2f6ca6f5c2f3faac2",
+                "reference": "13ce343935f0f91ca89605a2f6ca6f5c2f3faac2",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-11-14T01:06:16+00:00"
+        },
+        {
+            "name": "symfony/polyfill-xml",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-xml.git",
+                "reference": "64b6a864f18ab4fddad49f5025f805f6781dfabd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-xml/zipball/64b6a864f18ab4fddad49f5025f805f6781dfabd",
+                "reference": "64b6a864f18ab4fddad49f5025f805f6781dfabd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-xml": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Xml\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for xml's utf8_encode and utf8_decode functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-11-14T01:06:16+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "34b680b099972adb601873d8890ec26e5bb17b94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/34b680b099972adb601873d8890ec26e5bb17b94",
+                "reference": "34b680b099972adb601873d8890ec26e5bb17b94",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-12T14:14:56+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "602a15299dc01556013b07167d4f5d3a60e90d15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/602a15299dc01556013b07167d4f5d3a60e90d15",
+                "reference": "602a15299dc01556013b07167d4f5d3a60e90d15",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-12T14:14:56+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "friendsofphp/php-cs-fixer": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
In this update, I made some improvements in number parsing in Order entities. 

With this update, even if the user set the number as integer or float (which is better, as we're dealing with money numbers), it will parse the final order data array in the correct format. This update avoid the developer to set numbers in a format different from the expected by the RedePay webservice, so orders will always get the correct value.